### PR TITLE
[1459] When saving the data from the form we were using the CostItemV…

### DIFF
--- a/src/main/scala/controllers/ActionHandler.scala
+++ b/src/main/scala/controllers/ActionHandler.scala
@@ -112,8 +112,6 @@ class ActionHandler @Inject()(applications: ApplicationOps, applicationForms: Ap
     }
   }
 
-  implicit val costItemR = Json.reads[CostItem]
-
   def selectSectionForm(sectionNumber: Int, section: Option[ApplicationSection], questions: Map[String, Question], answers: Map[String, String], fields: Seq[Field], errs: FieldErrors, app: ApplicationOverview, appForm: ApplicationForm, opp: Opportunity): Result = {
     val formSection: ApplicationFormSection = appForm.sections.find(_.sectionNumber == sectionNumber).get
     val hints = hinting(JsonHelpers.unflatten(answers), checksFor(sectionNumber))

--- a/src/main/scala/controllers/ApplicationData.scala
+++ b/src/main/scala/controllers/ApplicationData.scala
@@ -18,6 +18,7 @@ object ApplicationData {
   implicit val dvReads = Json.reads[DateValues]
   implicit val dwdReads = Json.reads[DateWithDaysValues]
   implicit val civReads = Json.reads[CostItemValues]
+  implicit val ciReads = Json.reads[CostItem]
 
   private val provisionalDateValidator: DateWithDaysValidator = DateWithDaysValidator(allowPast = false, 1, 9)
 

--- a/src/main/scala/controllers/CostController.scala
+++ b/src/main/scala/controllers/CostController.scala
@@ -2,13 +2,15 @@ package controllers
 
 import javax.inject.Inject
 
-import cats.data.OptionT
+import cats.data.Validated.{Invalid, Valid}
+import cats.data.{OptionT, ValidatedNel}
 import cats.instances.future._
+import cats.syntax.validated._
 import controllers.FieldCheckHelpers.FieldErrors
-import forms.validation.CostItemValues
+import forms.validation.{CostItem, CostItemValidator, CostItemValues, FieldError}
 import models.ApplicationId
 import play.api.Logger
-import play.api.libs.json.{JsObject, Json}
+import play.api.libs.json.{JsError, JsObject, JsSuccess, Json}
 import play.api.mvc.{Action, Controller, Result}
 import services.ApplicationOps
 
@@ -17,16 +19,29 @@ import scala.concurrent.{ExecutionContext, Future}
 class CostController @Inject()(actionHandler: ActionHandler, applications: ApplicationOps)(implicit ec: ExecutionContext)
   extends Controller with ApplicationResults {
 
-  implicit val costItemValuesR = Json.reads[CostItemValues]
+  implicit val costItemValuesF = Json.format[CostItemValues]
+  implicit val costItemF = Json.format[CostItem]
 
   def addItem(applicationId: ApplicationId, sectionNumber: Int) = Action.async { implicit request =>
     showItemForm(applicationId, sectionNumber, JsObject(Seq()), List())
   }
 
+  def validateItem(o: JsObject): ValidatedNel[FieldError, CostItem] = {
+    (o \ "item").validate[CostItemValues] match {
+      case JsError(errs) => FieldError("item", s"could not convert $o to CostItemValues").invalidNel
+      case JsSuccess(values, _) =>
+        Logger.debug(values.toString)
+        CostItemValidator.validate("item", values)
+    }
+  }
+
   def saveItem(applicationId: ApplicationId, sectionNumber: Int) = Action.async(JsonForm.parser) { implicit request =>
-    applications.saveItem(applicationId, sectionNumber, request.body.values).flatMap {
-      case Nil => Future.successful(redirectToSectionForm(applicationId, sectionNumber))
-      case errs => showItemForm(applicationId, sectionNumber, request.body.values, errs)
+    validateItem(request.body.values) match {
+      case Valid(ci) => applications.saveItem(applicationId, sectionNumber, JsObject(Seq("item" -> Json.toJson(ci)))).flatMap {
+        case Nil => Future.successful(redirectToSectionForm(applicationId, sectionNumber))
+        case errs => showItemForm(applicationId, sectionNumber, request.body.values, errs)
+      }
+      case Invalid(errs) => showItemForm(applicationId, sectionNumber, request.body.values, errs.toList)
     }
   }
 
@@ -46,12 +61,12 @@ class CostController @Inject()(actionHandler: ActionHandler, applications: Appli
 
     import ApplicationData._
     import FieldCheckHelpers._
+
     val questions = questionsFor(sectionNumber)
     val fields = fieldsFor(sectionNumber).getOrElse(Seq())
     val cancelLink = sectionFormCall(applicationId, sectionNumber)
     val checks = itemChecksFor(sectionNumber)
     val hints = hinting(doc, checks)
-    Logger.debug(s"hinting $doc with $checks")
     val answers = JsonHelpers.flatten("", doc)
 
     details2.value.map {

--- a/src/main/scala/controllers/FieldCheck.scala
+++ b/src/main/scala/controllers/FieldCheck.scala
@@ -26,12 +26,6 @@ object FieldChecks {
     override def hint(path: String, value: JsValue): List[FieldHint] = validator.hintText(path, value)
   }
 
-  val currencyValidator = new FieldCheck {
-    override def apply(path: String, value: JsValue): List[FieldError] = CurrencyValidator.validate(path, decodeString(value)).fold(_.toList, _ => List())
-
-    override def hint(path: String, value: JsValue): List[FieldHint] = CurrencyValidator.hintText(path, value)
-  }
-
   def fromValidator[T: Reads](v: FieldValidator[T, _]): FieldCheck = new FieldCheck {
     override def toString: String = s"check from validator $v"
 
@@ -39,15 +33,10 @@ object FieldChecks {
       v.validate(path, x).fold(_.toList, _ => List())
     } match {
       case JsSuccess(msgs, _) => msgs
-      case JsError(errs) =>
-        Logger.debug(errs.toString)
-        List(FieldError(path, "Could not decode form values!"))
+      case JsError(errs) => List(FieldError(path, "Could not decode form values!"))
     }
 
-    override def hint(path: String, jv: JsValue): List[FieldHint] = {
-      Logger.debug(s"hinting value $jv at path $path")
-      v.hintText(path, jv)
-    }
+    override def hint(path: String, jv: JsValue): List[FieldHint] = v.hintText(path, jv)
   }
 
 

--- a/src/main/scala/forms/validation/CostItemValidator.scala
+++ b/src/main/scala/forms/validation/CostItemValidator.scala
@@ -28,11 +28,9 @@ case object CostItemValidator extends FieldValidator[CostItemValues, CostItem] {
 
 }
 
-case class CostSectionValidator(maxValue: BigDecimal) extends FieldValidator[List[CostItemValues], List[CostItem]] {
-  override def validate(path: String, itemValues: List[CostItemValues]): ValidatedNel[FieldError, List[CostItem]] = {
-    itemValues.map(CostItemValidator.validate(path, _)).sequenceU.andThen { items: List[CostItem] =>
-      if (items.map(_.cost).sum > maxValue) FieldError(path, s"Total requested exceeds limit. Please check costs of items.").invalidNel
-      else items.validNel
-    }
+case class CostSectionValidator(maxValue: BigDecimal) extends FieldValidator[List[CostItem], List[CostItem]] {
+  override def validate(path: String, items: List[CostItem]): ValidatedNel[FieldError, List[CostItem]] = {
+    if (items.map(_.cost).sum > maxValue) FieldError(path, s"Total requested exceeds limit. Please check costs of items.").invalidNel
+    else items.validNel
   }
 }

--- a/src/main/scala/forms/validation/CurrencyValidator.scala
+++ b/src/main/scala/forms/validation/CurrencyValidator.scala
@@ -2,6 +2,7 @@ package forms.validation
 
 import cats.data.ValidatedNel
 import cats.syntax.validated._
+import play.api.Logger
 
 import scala.util.Try
 

--- a/src/main/scala/services/ApplicationService.scala
+++ b/src/main/scala/services/ApplicationService.scala
@@ -46,18 +46,14 @@ class ApplicationService @Inject()(val ws: WSClient)(implicit val ec: ExecutionC
   override def saveItem(id: ApplicationId, sectionNumber: Int, doc: JsObject): Future[FieldErrors] = {
     Logger.debug(doc.toString)
 
-    FieldCheckHelpers.check(doc, itemChecksFor(sectionNumber)) match {
-      case Nil =>
-        val item = (doc \ "item").toOption.flatMap(_.validate[JsObject].asOpt).getOrElse(JsObject(Seq()))
-        item \ "itemNumber" match {
-          case JsDefined(JsNumber(itemNumber)) =>
-            val url = s"$baseUrl/application/${id.id}/section/$sectionNumber/item/$itemNumber"
-            put(url, item).map(_ => List())
-          case _ =>
-            val url = s"$baseUrl/application/${id.id}/section/$sectionNumber/items"
-            post(url, item).map(_ => List())
-        }
-      case errs => Future.successful(errs)
+    val item = (doc \ "item").toOption.flatMap(_.validate[JsObject].asOpt).getOrElse(JsObject(Seq()))
+    item \ "itemNumber" match {
+      case JsDefined(JsNumber(itemNumber)) =>
+        val url = s"$baseUrl/application/${id.id}/section/$sectionNumber/item/$itemNumber"
+        put(url, item).map(_ => List())
+      case _ =>
+        val url = s"$baseUrl/application/${id.id}/section/$sectionNumber/items"
+        post(url, item).map(_ => List())
     }
   }
 


### PR DESCRIPTION
…alidator to convert from CostItemValues to a CostItem, but it was the CostItemValues that were being stored in the database and subsequently re-loaded from the section for display, with validation re-applied. But the value of `cost` stored contained the comma and when we tried to convert that to a BigDecimal directly it failed (the CostItemValidator normalises the string to remove commas).

The fix in this commit causes the validated value, i.e. the CostItem, to be converted to json and stored in the database. This ties item handling even more closely to cost items, and away from a more generalised mechanism, but we'll live with that for the moment.

I think it points towards a more general solution not only for items, but for all section answer documents where we can update FieldCheck to return not just errors, but a ValidatedNel[FieldError, JsObject] and, if valid, we can store that object in the database instead of the raw field strings. We'd also need a mechansim to convert back from the stronger types to the strings to be sent to display in a form. This is a fair bit of work and I haven't tried to address that at this point.