### PR TITLE
Here's an experimental implementation of using markdown

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -40,6 +40,7 @@ libraryDependencies ++= Seq(
   "org.typelevel" %% "cats" % "0.7.2",
   "com.github.melrief" %% "pureconfig" % "0.1.6",
   "com.wellfactored" %% "play-bindings" % "1.1.0",
+  "org.planet42" %% "laika-core" % "0.6.0",
 
   "org.scalatestplus.play" %% "scalatestplus-play" % "1.5.1" % Test,
   "org.jsoup" % "jsoup" % "1.9.2" % Test

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -3,6 +3,5 @@ include "common.application.conf"
 play.crypto.secret = "YkJMLwA94Mjt1bd^>1kWRKbFcmYGTns=?=KznDEV6ICTxRf_MZ0Pyjb4:?XiH;7v"
 
 business {
-  baseUrl = "http://rifs-business-rifs-test.test.int.ukrifs.org"
-  baseUrl = ${?BUSINESS_BASE_URL}
+  baseUrl = ${BUSINESS_BASE_URL}
 }

--- a/src/main/scala/forms/MarkdownHelper.scala
+++ b/src/main/scala/forms/MarkdownHelper.scala
@@ -1,0 +1,13 @@
+package forms
+
+import laika.api._
+import laika.parse.markdown.Markdown
+import laika.render.HTML
+import play.twirl.api.Html
+
+import scala.language.postfixOps
+
+
+object MarkdownHelper {
+  def mdToHtml(s: String): Html = Html(Transform from Markdown to HTML fromString s toString)
+}

--- a/src/main/scala/models/Opportunity.scala
+++ b/src/main/scala/models/Opportunity.scala
@@ -2,7 +2,7 @@ package models
 
 case class OpportunityId(id: Long) extends AnyVal
 
-case class OpportunityDescriptionSection(sectionNumber:Int, title: String, paragraphs: Seq[String])
+case class OpportunitySection(sectionNumber: Int, title: String, text: Option[String])
 
 case class OpportunityValue(amount: BigDecimal, unit: String)
 
@@ -14,5 +14,5 @@ case class Opportunity(
                         startDate: String,
                         duration: Option[OpportunityDuration],
                         value: OpportunityValue,
-                        description: Seq[OpportunityDescriptionSection]
+                        sections: Seq[OpportunitySection]
                       )

--- a/src/main/scala/services/OpportunityService.scala
+++ b/src/main/scala/services/OpportunityService.scala
@@ -11,7 +11,7 @@ import play.api.libs.ws.WSClient
 import scala.concurrent.{ExecutionContext, Future}
 
 class OpportunityService @Inject()(val ws: WSClient)(implicit val ec: ExecutionContext) extends OpportunityOps with RestService with ValueClassFormats {
-  implicit val odsRead = Json.reads[OpportunityDescriptionSection]
+  implicit val odsRead = Json.reads[OpportunitySection]
   implicit val ovRead = Json.reads[OpportunityValue]
   implicit val odRead = Json.reads[OpportunityDuration]
   implicit val oppRead = Json.reads[Opportunity]

--- a/src/main/twirl/views/renderers/preview/textAreaField.scala.html
+++ b/src/main/twirl/views/renderers/preview/textAreaField.scala.html
@@ -1,6 +1,8 @@
 @(field: forms.TextAreaField, answers: Map[String, String])
 
+@import forms.MarkdownHelper.mdToHtml
+
 <div>
     <h3>@field.label</h3>
-    @answers.getOrElse(field.name, "").split("\n\n").filterNot(_ == "").map { p => <p class="text preview-text">@p</p> }
+    @answers.get(field.name).map(mdToHtml).getOrElse("")
 </div>

--- a/src/main/twirl/views/showOpportunity.scala.html
+++ b/src/main/twirl/views/showOpportunity.scala.html
@@ -1,7 +1,7 @@
 @(applicationId: ApplicationFormId, opportunity: Opportunity, sectionNumber: Int)
 
 @sectionLink(title: String, sectionNum: Int) = {
-    <span class="part-number">@sectionNum.</span>
+    <span class="part-number">@sectionNum. </span>
     @if(sectionNum == sectionNumber) {
         @title
     } else {
@@ -10,7 +10,7 @@
 }
 
 @titleCols() = @{
-    val titles = opportunity.description.sortBy(_.sectionNumber).map(s => (s.title, s.sectionNumber)).zipWithIndex
+    val titles = opportunity.sections.sortBy(_.sectionNumber).map(s => (s.title, s.sectionNumber)).zipWithIndex
     val midpoint: Int = Math.round(titles.length / 2.0).toInt
     val (leftCols, b) = titles.splitAt(midpoint)
     val rightCols = b.map(Some(_)) :+ None
@@ -18,15 +18,15 @@
 }
 
 @nextSection = @{
-    opportunity.description.find(_.sectionNumber == sectionNumber + 1)
+    opportunity.sections.find(_.sectionNumber == sectionNumber + 1)
 }
 
 @prevSection = @{
-    opportunity.description.find(_.sectionNumber == sectionNumber - 1)
+    opportunity.sections.find(_.sectionNumber == sectionNumber - 1)
 }
 
 @currentSection = @{
-    opportunity.description.find(_.sectionNumber == sectionNumber)
+    opportunity.sections.find(_.sectionNumber == sectionNumber)
 }
 
 @main(s"Opportunity ${opportunity.id.id}") {
@@ -97,9 +97,7 @@
 
         <article>
         <h2 class="heading-large">@s.sectionNumber. @s.title</h2>
-        @s.paragraphs.map { p =>
-        <p class="text">@p</p>
-        }
+        @s.text.map(forms.MarkdownHelper.mdToHtml)
 
             <div class="rifs-form-buttons">
                 <p>


### PR DESCRIPTION
## Do not Merge!

Please _don't_ merge this PR yet! I've opened it so we can have a discussion about whether we think this is the way we'd like to go, so any and all comments welcome.

I found a library called Laika (http://planet42.github.io/Laika/introduction/intro.html) that makes it literally one line of code to process a string as Markdown and produce HTML from it. I've wired this into the TextAreaField preview and also the Opportunity section display. As part of this I've made changes in the backend (on a similarly named branch) to change the way the section text is held. Now, instead of having a separate paragraph table, the section text is just a column in the `section` table (up to 4k at the moment) that the frontend interprets as markdown.

Laika has a lot of flexibility in how the HTML is rendered so we can tailor it to what we need. We can change the generated HTML for individual markdown elements, or we can create templates for bigger customisations.
