### PR TITLE
Refactor/introduce actions

### DIFF
--- a/src/main/scala/actions/AppDetailAction.scala
+++ b/src/main/scala/actions/AppDetailAction.scala
@@ -1,0 +1,24 @@
+package actions
+
+import javax.inject.Inject
+
+import models.{Application, ApplicationDetail, ApplicationId}
+import play.api.mvc.Results._
+import play.api.mvc._
+import services.ApplicationOps
+
+import scala.concurrent.{ExecutionContext, Future}
+
+case class AppDetailRequest[A](appDetail: ApplicationDetail, request: Request[A]) extends WrappedRequest[A](request)
+
+class AppDetailAction @Inject()(applications: ApplicationOps)(implicit ec: ExecutionContext) {
+  def apply(id: ApplicationId): ActionBuilder[AppDetailRequest] =
+    new ActionBuilder[AppDetailRequest] {
+      override def invokeBlock[A](request: Request[A], next: (AppDetailRequest[A]) => Future[Result]): Future[Result] = {
+        applications.detail(id).flatMap {
+          case Some(app) => next(AppDetailRequest(app, request))
+          case None => Future.successful(NotFound(s"No application with id ${id.id} exists"))
+        }
+      }
+    }
+}

--- a/src/main/scala/actions/AppSectionAction.scala
+++ b/src/main/scala/actions/AppSectionAction.scala
@@ -1,0 +1,24 @@
+package actions
+
+import javax.inject.Inject
+
+import models.{ApplicationId, ApplicationSectionDetail}
+import play.api.mvc.Results._
+import play.api.mvc._
+import services.ApplicationOps
+
+import scala.concurrent.{ExecutionContext, Future}
+
+case class AppSectionRequest[A](appSection: ApplicationSectionDetail, request: Request[A]) extends WrappedRequest[A](request)
+
+class AppSectionAction @Inject()(applications: ApplicationOps)(implicit ec: ExecutionContext) {
+  def apply(id: ApplicationId, sectionNum: Int): ActionBuilder[AppSectionRequest] =
+    new ActionBuilder[AppSectionRequest] {
+      override def invokeBlock[A](request: Request[A], next: (AppSectionRequest[A]) => Future[Result]): Future[Result] = {
+        applications.sectionDetail(id, sectionNum).flatMap {
+          case Some(app) => next(AppSectionRequest(app, request))
+          case None => Future.successful(NotFound(s"No application section with id ${id.id} and section number $sectionNum exists"))
+        }
+      }
+    }
+}

--- a/src/main/scala/controllers/ActionHandler.scala
+++ b/src/main/scala/controllers/ActionHandler.scala
@@ -17,66 +17,50 @@ class ActionHandler @Inject()(applications: ApplicationOps, applicationForms: Ap
   import ApplicationData._
   import FieldCheckHelpers._
 
-  def doSave(id: ApplicationId, sectionNumber: Int, fieldValues: JsObject): Future[Result] = {
-    gatherSectionDetails(id, sectionNumber).flatMap {
-      case Some(app) =>
-        app.formSection.sectionType match {
-          case SectionTypeForm =>
-            JsonHelpers.allFieldsEmpty(fieldValues) match {
-              case true => applications.deleteSection(id, sectionNumber).map(_ => redirectToOverview(id))
-              case false => applications.saveSection(id, sectionNumber, fieldValues).map(_ => redirectToOverview(id))
-            }
-          case SectionTypeList => Future.successful(redirectToOverview(id))
+  def doSave(app: ApplicationSectionDetail, fieldValues: JsObject): Future[Result] = {
+    app.formSection.sectionType match {
+      case SectionTypeForm =>
+        JsonHelpers.allFieldsEmpty(fieldValues) match {
+          case true => applications.deleteSection(app.id, app.sectionNumber).map(_ => redirectToOverview(app.id))
+          case false => applications.saveSection(app.id, app.sectionNumber, fieldValues).map(_ => redirectToOverview(app.id))
         }
-      case None => Future.successful(NotFound)
+      case SectionTypeList => Future.successful(redirectToOverview(app.id))
     }
   }
 
-  def doComplete(id: ApplicationId, sectionNumber: Int, fieldValues: JsObject): Future[Result] = {
-    gatherSectionDetails(id, sectionNumber).flatMap {
-      case Some(app) =>
-        val answersF: Future[Option[JsObject]] = app.formSection.sectionType match {
-          case SectionTypeForm => Future.successful(Some(fieldValues))
-          // Instead of using the values that were passed in from the form we'll use the values that
-          // have already been saved against the item list, since these were created by the add-item
-          // form.
-          case SectionTypeList => applications.getSection(id, sectionNumber).map(_.map(_.answers))
-        }
+  def doComplete(app: ApplicationSectionDetail, fieldValues: JsObject): Future[Result] = {
+    val answers = app.formSection.sectionType match {
+      case SectionTypeForm => fieldValues
+      // Instead of using the values that were passed in from the form we'll use the values that
+      // have already been saved against the item list, since these were created by the add-item
+      // form.
+      case SectionTypeList => app.section.map(_.answers).getOrElse(JsObject(Seq()))
+    }
 
-        answersF.flatMap {
-          case Some(answers) =>
-            applications.completeSection(id, sectionNumber, answers).flatMap {
-              case Nil => Future.successful(redirectToOverview(id))
-              case errs => redisplaySectionForm(id, sectionNumber, answers, errs)
-            }
-          case None => Future.successful(NotFound)
-        }
-      case None => Future.successful(NotFound)
+    applications.completeSection(app.id, app.sectionNumber, answers).map {
+      case Nil => redirectToOverview(app.id)
+      case errs => redisplaySectionForm(app, answers, errs)
     }
   }
 
-  def doSaveItem(id: ApplicationId, sectionNumber: Int, fieldValues: JsObject): Future[Result] = {
+  def doSaveItem(app: ApplicationSectionDetail, fieldValues: JsObject): Future[Result] = {
     JsonHelpers.allFieldsEmpty(fieldValues) match {
-      case true => applications.deleteSection(id, sectionNumber).map(_ => redirectToOverview(id))
-      case false => applications.saveItem(id, sectionNumber, fieldValues).flatMap {
-        case Nil => Future.successful(redirectToOverview(id))
-        case errs => redisplaySectionForm(id, sectionNumber, fieldValues, errs)
+      case true => applications.deleteSection(app.id, app.sectionNumber).map(_ => redirectToOverview(app.id))
+      case false => applications.saveItem(app.id, app.sectionNumber, fieldValues).flatMap {
+        case Nil => Future.successful(redirectToOverview(app.id))
+        case errs => Future.successful(redisplaySectionForm(app, fieldValues, errs))
       }
     }
   }
 
-  def doPreview(id: ApplicationId, sectionNumber: Int, fieldValues: JsObject): Future[Result] = {
-    gatherSectionDetails(id, sectionNumber).flatMap {
-      case Some(app) =>
-        app.formSection.sectionType match {
-          case SectionTypeForm =>
-            val errs = check(fieldValues, previewChecksFor(app.formSection))
-            if (errs.isEmpty) applications.saveSection(id, sectionNumber, fieldValues).map(_ => redirectToPreview(id, sectionNumber))
-            else redisplaySectionForm(id, sectionNumber, fieldValues, errs)
+  def doPreview(app: ApplicationSectionDetail, fieldValues: JsObject): Future[Result] = {
+    app.formSection.sectionType match {
+      case SectionTypeForm =>
+        val errs = check(fieldValues, previewChecksFor(app.formSection))
+        if (errs.isEmpty) applications.saveSection(app.id, app.sectionNumber, fieldValues).map(_ => redirectToPreview(app.id, app.sectionNumber))
+        else Future.successful(redisplaySectionForm(app, fieldValues, errs))
 
-          case SectionTypeList => Future.successful(redirectToPreview(id, sectionNumber))
-        }
-      case None => Future.successful(NotFound)
+      case SectionTypeList => Future.successful(redirectToPreview(app.id, app.sectionNumber))
     }
   }
 
@@ -84,54 +68,42 @@ class ActionHandler @Inject()(applications: ApplicationOps, applicationForms: Ap
     applications.submit(id)
   }
 
-  def completeAndPreview(id: ApplicationId, sectionNumber: Int, fieldValues: JsObject): Future[Result] = {
-    gatherSectionDetails(id, sectionNumber).flatMap {
-      case Some(app) =>
-        val answersF: Future[Option[JsObject]] = app.formSection.sectionType match {
-          case SectionTypeForm => Future.successful(Some(fieldValues))
-          case SectionTypeList => applications.getSection(id, sectionNumber).map(_.map(_.answers))
-        }
-
-        answersF.flatMap {
-          case Some(answers) =>
-            val previewCheckErrs = check(answers, previewChecksFor(app.formSection))
-            if (previewCheckErrs.isEmpty) {
-              JsonHelpers.allFieldsEmpty(answers) match {
-                case true => applications.deleteSection(id, sectionNumber).map(_ => redirectToOverview(id))
-                case false => applications.completeSection(id, sectionNumber, answers).flatMap {
-                  case Nil => Future.successful(redirectToPreview(id, sectionNumber))
-                  case errs => redisplaySectionForm(id, sectionNumber, answers, errs)
-                }
-              }
-            } else redisplaySectionForm(id, sectionNumber, answers, previewCheckErrs)
-
-          case None => Future.successful(NotFound)
-        }
-      case None => Future.successful(NotFound)
+  def completeAndPreview(app: ApplicationSectionDetail, fieldValues: JsObject): Future[Result] = {
+    val answers = app.formSection.sectionType match {
+      case SectionTypeForm => fieldValues
+      // Instead of using the values that were passed in from the form we'll use the values that
+      // have already been saved against the item list, since these were created by the add-item
+      // form.
+      case SectionTypeList => app.section.map(_.answers).getOrElse(JsObject(Seq()))
     }
+
+    val previewCheckErrs = check(answers, previewChecksFor(app.formSection))
+    if (previewCheckErrs.isEmpty) {
+      JsonHelpers.allFieldsEmpty(answers) match {
+        case true => applications.deleteSection(app.id, app.sectionNumber).map(_ => redirectToOverview(app.id))
+        case false => applications.completeSection(app.id, app.sectionNumber, answers).map {
+          case Nil => redirectToPreview(app.id, app.sectionNumber)
+          case errs => redisplaySectionForm(app, answers, errs)
+        }
+      }
+    } else Future.successful(redisplaySectionForm(app, answers, previewCheckErrs))
   }
 
   def redirectToPreview(id: ApplicationId, sectionNumber: Int) =
     Redirect(routes.ApplicationPreviewController.previewSection(id, sectionNumber))
 
   def renderSectionForm(app: ApplicationSectionDetail,
-                        sectionNumber: Int,
                         errs: FieldErrors,
                         hints: FieldHints): Result = {
     val answers = app.section.map { s => s.answers }.getOrElse(JsObject(List.empty))
-    selectSectionForm(app, sectionNumber, answers, errs)
+    selectSectionForm(app, answers, errs)
   }
 
-  def redisplaySectionForm(id: ApplicationId, sectionNumber: Int, answers: JsObject, errs: FieldErrors = noErrors): Future[Result] = {
-    val ft = gatherSectionDetails(id, sectionNumber)
-
-    ft.map {
-      case (Some(app)) => selectSectionForm(app, sectionNumber, answers, errs)
-      case (None) => NotFound
-    }
+  def redisplaySectionForm(app: ApplicationSectionDetail, answers: JsObject, errs: FieldErrors = noErrors): Result = {
+    selectSectionForm(app, answers, errs)
   }
 
-  def selectSectionForm(app: ApplicationSectionDetail, sectionNumber: Int, answers: JsObject, errs: FieldErrors): Result = {
+  def selectSectionForm(app: ApplicationSectionDetail, answers: JsObject, errs: FieldErrors): Result = {
     val checks = app.formSection.fields.map(f => f.name -> f.check).toMap
     val hints = hinting(answers, checks)
 
@@ -143,13 +115,10 @@ class ActionHandler @Inject()(applications: ApplicationOps, applicationForms: Ap
             val itemValues: Seq[JsValue] = (answers \ "items").validate[JsArray].asOpt.map(_.value).getOrElse(Seq())
             val costItems = itemValues.flatMap(_.validate[CostItem].asOpt)
             Ok(views.html.sectionList(app, costItems, answers, errs, hints))
-          case _ => Redirect(controllers.routes.CostController.addItem(app.id, sectionNumber))
+          case _ => Redirect(controllers.routes.CostController.addItem(app.id, app.formSection.sectionNumber))
         }
     }
   }
-
-  def gatherSectionDetails(id: ApplicationId, sectionNumber: Int): Future[Option[ApplicationSectionDetail]] =
-    applications.sectionDetail(id, sectionNumber)
 
   def previewChecksFor(formSection: ApplicationFormSection): Map[String, FieldCheck] =
     formSection.fields.map(f => f.name -> f.previewCheck).toMap

--- a/src/main/scala/models/Application.scala
+++ b/src/main/scala/models/Application.scala
@@ -36,7 +36,9 @@ case class ApplicationSectionDetail(
                                      opportunity: OpportunitySummary,
                                      formSection: ApplicationFormSection,
                                      section: Option[ApplicationSection]
-                                   )
+                                   ){
+  val sectionNumber = formSection.sectionNumber
+}
 
 case class SubmittedApplicationRef(applicationRef: Long) extends AnyVal
 


### PR DESCRIPTION
This PR moves the boilerplate code of looking up `ApplicationSectionDetails` and `ApplicationDetails` out of the controller functions and into specialised `Action`s. The details objects are available on the `request` that is passed to the action block and, if the details don't exist then the `Action`s return a `NotFound` and our action blocks are not run.