### PR TITLE
Feature/ui 30 nov

### DIFF
--- a/src/main/public/javascripts/application-rules.js
+++ b/src/main/public/javascripts/application-rules.js
@@ -54,6 +54,7 @@
 
 $(document).ready(function () {
     jQuery.fx.off = true;
+    var GOVUK = window.GOVUK || {};
 
     // Don't enhance the selection buttons on IE8 as it can't handle the javascript.
     if (navigator.appVersion.indexOf('MSIE 8.') === -1) {

--- a/src/main/public/javascripts/application-rules.js
+++ b/src/main/public/javascripts/application-rules.js
@@ -57,7 +57,7 @@ $(document).ready(function () {
 
     // Don't enhance the selection buttons on IE8 as it can't handle the javascript.
     if (navigator.appVersion.indexOf('MSIE 8.') === -1) {
-        var selectionButtons = new GOVUK.SelectionButtons($(".block-label input[type='radio'], .block-label input[type='checkbox']"));
+        var selectionButtons = new GOVUK.SelectionButtons($('.block-label input[type="radio"], .block-label input[type="checkbox"]'));
     }
 
     // Turn the tabs on if the correct structures exist in the page

--- a/src/main/public/javascripts/application-rules.js
+++ b/src/main/public/javascripts/application-rules.js
@@ -57,7 +57,7 @@ $(document).ready(function () {
 
     // Don't enhance the selection buttons on IE8 as it can't handle the javascript.
     if (navigator.appVersion.indexOf('MSIE 8.') === -1) {
-        var selectionButtons = new GOVUK.SelectionButtons($("label input[type='radio'], label input[type='checkbox']"));
+        var selectionButtons = new GOVUK.SelectionButtons($(".block-label input[type='radio'], .block-label input[type='checkbox']"));
     }
 
     // Turn the tabs on if the correct structures exist in the page

--- a/src/main/twirl/views/applicationPreview.scala.html
+++ b/src/main/twirl/views/applicationPreview.scala.html
@@ -23,7 +23,7 @@
 }
 
 @formatId(id: Long) = @{
-    f"RIFS$id%05d"
+    f"RIFS $id%04d"
 }
 
 @main(s"Opportunity ${app.opportunity.title} - RIFS", backLink=Some(BackLink("Return to application overview",controllers.routes.ApplicationController.show(app.id).url)), displayUserName=Some("Experienced Eric")) {

--- a/src/main/twirl/views/costItemForm.scala.html
+++ b/src/main/twirl/views/costItemForm.scala.html
@@ -10,11 +10,6 @@
 )
     @import partials._
 
-
-@formatId(id: Long) = @{
-    f"RIFS $id%04d"
-}
-
 @createOrSave = @{
     itemNumber match {
         case Some(n) => controllers.routes.CostController.saveItem(app.id, app.formSection.sectionNumber, n)

--- a/src/main/twirl/views/costItemForm.scala.html
+++ b/src/main/twirl/views/costItemForm.scala.html
@@ -12,7 +12,7 @@
 
 
 @formatId(id: Long) = @{
-    f"RIFS$id%05d"
+    f"RIFS $id%04d"
 }
 
 @createOrSave = @{

--- a/src/main/twirl/views/costSectionList.scala.html
+++ b/src/main/twirl/views/costSectionList.scala.html
@@ -9,10 +9,6 @@
 
     @import partials._
 
-@formatId(id: Long) = @{
-    f"RIFS $id%04d"
-}
-
 @main(s"${formSection.title} - RIFS", backLink=Some(BackLink("Return to application overview",controllers.routes.ApplicationController.show(app.id).url)), displayUserName=Some("Experienced Eric")) {
     <div class="grid-row">
         <div class="column-two-thirds">

--- a/src/main/twirl/views/costSectionList.scala.html
+++ b/src/main/twirl/views/costSectionList.scala.html
@@ -10,7 +10,7 @@
     @import partials._
 
 @formatId(id: Long) = @{
-    f"RIFS$id%05d"
+    f"RIFS $id%04d"
 }
 
 @main(s"${formSection.title} - RIFS", backLink=Some(BackLink("Return to application overview",controllers.routes.ApplicationController.show(app.id).url)), displayUserName=Some("Experienced Eric")) {

--- a/src/main/twirl/views/listSectionPreview.scala.html
+++ b/src/main/twirl/views/listSectionPreview.scala.html
@@ -7,7 +7,7 @@
 )
 
 @formatId(id: Long) = @{
-    f"RIFS$id%05d"
+    f"RIFS $id%04d"
 }
 
 @main(s"${app.formSection.title} - RIFS", backLink=Some(BackLink("Return to application overview",controllers.routes.ApplicationController.show(app.id).url)), displayUserName=Some("Experienced Eric")) {

--- a/src/main/twirl/views/listSectionPreview.scala.html
+++ b/src/main/twirl/views/listSectionPreview.scala.html
@@ -6,9 +6,7 @@
         editButton: Option[String]
 )
 
-@formatId(id: Long) = @{
-    f"RIFS $id%04d"
-}
+@import partials._
 
 @main(s"${app.formSection.title} - RIFS", backLink=Some(BackLink("Return to application overview",controllers.routes.ApplicationController.show(app.id).url)), displayUserName=Some("Experienced Eric")) {
     <div class="grid-row">

--- a/src/main/twirl/views/manage/editDeadlinesForm.scala.html
+++ b/src/main/twirl/views/manage/editDeadlinesForm.scala.html
@@ -14,9 +14,7 @@
     <span class="error-message" role="alert">@e.err</span>
 }
 
-@formatId(id: Long) = @{
-    f"RIFS $id%04d"
-}
+@import views.html.partials._
 
 @main("RIFS - Edit Deadline", displayUserName = Some("Portfolio Peter")) {
 

--- a/src/main/twirl/views/manage/editDeadlinesForm.scala.html
+++ b/src/main/twirl/views/manage/editDeadlinesForm.scala.html
@@ -15,7 +15,7 @@
 }
 
 @formatId(id: Long) = @{
-    f"RIFS$id%05d"
+    f"RIFS $id%04d"
 }
 
 @main("RIFS - Edit Deadline", displayUserName = Some("Portfolio Peter")) {

--- a/src/main/twirl/views/manage/editTitleForm.scala.html
+++ b/src/main/twirl/views/manage/editTitleForm.scala.html
@@ -10,9 +10,7 @@
     errs.filter(p => p.path == field.name)
 }
 
-@formatId(id: Long) = @{
-    f"RIFS $id%04d"
-}
+@import views.html.partials._
 
 @main("RIFS - Edit Title", displayUserName = Some("Portfolio Peter")) {
 

--- a/src/main/twirl/views/manage/editTitleForm.scala.html
+++ b/src/main/twirl/views/manage/editTitleForm.scala.html
@@ -15,7 +15,7 @@
 }
 
 @formatId(id: Long) = @{
-    f"RIFS$id%05d"
+    f"RIFS $id%04d"
 }
 
 @main("RIFS - Edit Title", displayUserName = Some("Portfolio Peter")) {

--- a/src/main/twirl/views/manage/previewOpportunity.scala.html
+++ b/src/main/twirl/views/manage/previewOpportunity.scala.html
@@ -8,7 +8,7 @@
 }
 
 @formatId(id: Long) = @{
-f"RIFS$id%05d"
+f"RIFS $id%04d"
 }
 
 @main(s"Opportunity template setup - RIFS", displayUserName=username(),

--- a/src/main/twirl/views/manage/previewOpportunity.scala.html
+++ b/src/main/twirl/views/manage/previewOpportunity.scala.html
@@ -7,9 +7,7 @@
     Some("Portfolio Peter")
 }
 
-@formatId(id: Long) = @{
-f"RIFS $id%04d"
-}
+@import views.html.partials._
 
 @main(s"Opportunity template setup - RIFS", displayUserName=username(),
 backLink=Some(BackLink("Opportunity library", controllers.manage.routes.OpportunityController.showOpportunityLibrary().url))) {

--- a/src/main/twirl/views/manage/viewDeadlines.scala.html
+++ b/src/main/twirl/views/manage/viewDeadlines.scala.html
@@ -4,9 +4,7 @@
         questions: Map[String, Question],
         answers: play.api.libs.json.JsObject)
 
-@formatId(id: Long) = @{
-    f"RIFS $id%04d"
-}
+@import views.html.partials._
 
 @main(s"${opp.title} - RIFS", backLink = Some(BackLink("Opportunity template", controllers.routes.OpportunityController.showOverviewPage(opp.id).url)), displayUserName=Some("Portfolio Peter")) {
     <div class="grid-row">

--- a/src/main/twirl/views/manage/viewDeadlines.scala.html
+++ b/src/main/twirl/views/manage/viewDeadlines.scala.html
@@ -5,7 +5,7 @@
         answers: play.api.libs.json.JsObject)
 
 @formatId(id: Long) = @{
-    f"RIFS$id%05d"
+    f"RIFS $id%04d"
 }
 
 @main(s"${opp.title} - RIFS", backLink = Some(BackLink("Opportunity template", controllers.routes.OpportunityController.showOverviewPage(opp.id).url))) {

--- a/src/main/twirl/views/manage/viewDescription.scala.html
+++ b/src/main/twirl/views/manage/viewDescription.scala.html
@@ -1,10 +1,8 @@
 @(
   opp: Opportunity
 )
+@import views.html.partials._
 
-@formatId(id: Long) = @{
-    f"RIFS $id%04d"
-}
 
 @main(s"${opp.title} - RIFS", backLink=Some(BackLink("Opportunity template",controllers.routes.OpportunityController.showOverviewPage(opp.id).url)), displayUserName=Some("Portfolio Peter")) {
     <div class="grid-row">

--- a/src/main/twirl/views/manage/viewDescription.scala.html
+++ b/src/main/twirl/views/manage/viewDescription.scala.html
@@ -3,7 +3,7 @@
 )
 
 @formatId(id: Long) = @{
-    f"RIFS$id%05d"
+    f"RIFS $id%04d"
 }
 
 @main(s"${opp.title} - RIFS", backLink=Some(BackLink("Opportunity template",controllers.routes.OpportunityController.showOverviewPage(opp.id).url))) {

--- a/src/main/twirl/views/manage/viewGrantValue.scala.html
+++ b/src/main/twirl/views/manage/viewGrantValue.scala.html
@@ -3,7 +3,7 @@
 )
 
 @formatId(id: Long) = @{
-    f"RIFS$id%05d"
+    f"RIFS $id%04d"
 }
 
 @main(s"${opp.title} - RIFS", backLink=Some(BackLink("Opportunity template",controllers.routes.OpportunityController.showOverviewPage(opp.id).url))) {

--- a/src/main/twirl/views/manage/viewGrantValue.scala.html
+++ b/src/main/twirl/views/manage/viewGrantValue.scala.html
@@ -1,10 +1,7 @@
 @(
   opp: Opportunity
 )
-
-@formatId(id: Long) = @{
-    f"RIFS $id%04d"
-}
+@import views.html.partials._
 
 @main(s"${opp.title} - RIFS", backLink=Some(BackLink("Opportunity template",controllers.routes.OpportunityController.showOverviewPage(opp.id).url)), displayUserName=Some("Portfolio Peter")) {
     <div class="grid-row">

--- a/src/main/twirl/views/manage/viewOppSection.scala.html
+++ b/src/main/twirl/views/manage/viewOppSection.scala.html
@@ -4,7 +4,7 @@ sectionNumber: Int
 )
 
 @formatId(id: Long) = @{
-    f"RIFS$id%05d"
+    f"RIFS $id%04d"
 }
 
 @currentSection = @{

--- a/src/main/twirl/views/manage/viewOppSection.scala.html
+++ b/src/main/twirl/views/manage/viewOppSection.scala.html
@@ -2,10 +2,8 @@
 opp: Opportunity,
 sectionNumber: Int
 )
+@import views.html.partials._
 
-@formatId(id: Long) = @{
-    f"RIFS $id%04d"
-}
 
 @currentSection = @{
 opp.description.find(_.sectionNumber == sectionNumber)

--- a/src/main/twirl/views/manage/viewQuestions.scala.html
+++ b/src/main/twirl/views/manage/viewQuestions.scala.html
@@ -2,10 +2,8 @@
         opp: Opportunity,
         formSection: ApplicationFormSection
 )
+@import views.html.partials._
 
-@formatId(id: Long) = @{
-    f"RIFS $id%04d"
-}
 
 @main(s"${formSection.title} - RIFS", backLink = Some(BackLink("Opportunity Template", controllers.routes.OpportunityController.showOverviewPage(opp.id).url)), displayUserName=Some("Portfolio Peter")) {
     <div class="grid-row">

--- a/src/main/twirl/views/manage/viewQuestions.scala.html
+++ b/src/main/twirl/views/manage/viewQuestions.scala.html
@@ -4,7 +4,7 @@
 )
 
 @formatId(id: Long) = @{
-    f"RIFS$id%05d"
+    f"RIFS $id%04d"
 }
 
 @main(s"${formSection.title} - RIFS", backLink = Some(BackLink("Opportunity Template", controllers.routes.OpportunityController.showOverviewPage(opp.id).url))) {

--- a/src/main/twirl/views/manage/viewTitle.scala.html
+++ b/src/main/twirl/views/manage/viewTitle.scala.html
@@ -3,7 +3,7 @@
 )
 
 @formatId(id: Long) = @{
-    f"RIFS$id%05d"
+    f"RIFS $id%04d"
 }
 
 @main(s"${opp.title} - RIFS", backLink=Some(BackLink("Opportunity template",controllers.routes.OpportunityController.showOverviewPage(opp.id).url))) {

--- a/src/main/twirl/views/manage/viewTitle.scala.html
+++ b/src/main/twirl/views/manage/viewTitle.scala.html
@@ -2,9 +2,7 @@
   opp: Opportunity
 )
 
-@formatId(id: Long) = @{
-    f"RIFS $id%04d"
-}
+@import views.html.partials._
 
 @main(s"${opp.title} - RIFS", backLink=Some(BackLink("Opportunity template",controllers.routes.OpportunityController.showOverviewPage(opp.id).url)), displayUserName=Some("Portfolio Peter")) {
     <div class="grid-row">

--- a/src/main/twirl/views/partials/formatId.scala.html
+++ b/src/main/twirl/views/partials/formatId.scala.html
@@ -1,3 +1,3 @@
 @(id: Long)
 
-@{f"RIFS$id%05d"}
+@{f"RIFS $id%04d"}

--- a/src/main/twirl/views/partials/formatId.scala.html
+++ b/src/main/twirl/views/partials/formatId.scala.html
@@ -1,0 +1,3 @@
+@(id: Long)
+
+@{f"RIFS$id%05d"}

--- a/src/main/twirl/views/partials/sidebar.scala.html
+++ b/src/main/twirl/views/partials/sidebar.scala.html
@@ -7,7 +7,7 @@
 <h2 class="heading-medium no-top-margin">Support</h2>
 <ul class="list spacious">
     <li>
-        <a href="@controllers.routes.OpportunityController.showGuidancePage(opportunityId)" target="_blank">
+        <a href="@controllers.routes.OpportunityController.showGuidancePage(opportunityId)">
             Guidance on seminars</a>
     </li>
     <li>

--- a/src/main/twirl/views/renderers/preview/costListField.scala.html
+++ b/src/main/twirl/views/renderers/preview/costListField.scala.html
@@ -1,10 +1,5 @@
 @(costs: Seq[forms.validation.CostItem])
 
-@formatId(id: Long) = @{
-    f"RIFS$id%05d"
-}
-
-
 <table class="rifs-costs-table">
     <thead>
         <tr>

--- a/src/main/twirl/views/sectionForm.scala.html
+++ b/src/main/twirl/views/sectionForm.scala.html
@@ -6,10 +6,6 @@
 )
 @import partials._
 
-@formatId(id: Long) = @{
-    f"RIFS $id%04d"
-}
-
 @main(s"${app.formSection.title} - RIFS", backLink=Some(BackLink("Return to application overview",controllers.routes.ApplicationController.show(app.id).url)), displayUserName=Some("Experienced Eric")) {
     <div class="grid-row">
         <div class="column-two-thirds">

--- a/src/main/twirl/views/sectionForm.scala.html
+++ b/src/main/twirl/views/sectionForm.scala.html
@@ -7,7 +7,7 @@
 @import partials._
 
 @formatId(id: Long) = @{
-    f"RIFS$id%05d"
+    f"RIFS $id%04d"
 }
 
 @main(s"${app.formSection.title} - RIFS", backLink=Some(BackLink("Return to application overview",controllers.routes.ApplicationController.show(app.id).url)), displayUserName=Some("Experienced Eric")) {

--- a/src/main/twirl/views/sectionList.scala.html
+++ b/src/main/twirl/views/sectionList.scala.html
@@ -7,10 +7,6 @@
 )
 @import partials._
 
-@formatId(id: Long) = @{
-    f"RIFS $id%04d"
-}
-
 @main(s"${app.formSection.title} - RIFS", backLink=Some(BackLink("Return to application overview",controllers.routes.ApplicationController.show(app.id).url)), displayUserName=Some("Experienced Eric")) {
     <div class="grid-row">
         <div class="column-two-thirds">

--- a/src/main/twirl/views/sectionList.scala.html
+++ b/src/main/twirl/views/sectionList.scala.html
@@ -8,7 +8,7 @@
 @import partials._
 
 @formatId(id: Long) = @{
-    f"RIFS$id%05d"
+    f"RIFS $id%04d"
 }
 
 @main(s"${app.formSection.title} - RIFS", backLink=Some(BackLink("Return to application overview",controllers.routes.ApplicationController.show(app.id).url)), displayUserName=Some("Experienced Eric")) {

--- a/src/main/twirl/views/sectionPreview.scala.html
+++ b/src/main/twirl/views/sectionPreview.scala.html
@@ -7,7 +7,7 @@
 )
 
 @formatId(id: Long) = @{
-    f"RIFS$id%05d"
+    f"RIFS $id%04d"
 }
 
 @main(s"${app.formSection.title} - RIFS", backLink=Some(BackLink("Return to application overview",controllers.routes.ApplicationController.show(app.id).url)), displayUserName=Some("Experienced Eric")) {

--- a/src/main/twirl/views/sectionPreview.scala.html
+++ b/src/main/twirl/views/sectionPreview.scala.html
@@ -6,9 +6,7 @@
         editButton: Option[String]
 )
 
-@formatId(id: Long) = @{
-    f"RIFS $id%04d"
-}
+@import partials._
 
 @main(s"${app.formSection.title} - RIFS", backLink=Some(BackLink("Return to application overview",controllers.routes.ApplicationController.show(app.id).url)), displayUserName=Some("Experienced Eric")) {
     <div class="grid-row">

--- a/src/main/twirl/views/showApplicationForm.scala.html
+++ b/src/main/twirl/views/showApplicationForm.scala.html
@@ -4,7 +4,7 @@
 @(app: ApplicationDetail, errs: Seq[forms.validation.SectionError])
 
 @formatId(id: Long) = @{
-f"RIFS$id%05d"
+f"RIFS $id%04d"
 }
 
 @errorClass = @{if(errs.nonEmpty) "rifs-error-panel" else ""}

--- a/src/main/twirl/views/showApplicationForm.scala.html
+++ b/src/main/twirl/views/showApplicationForm.scala.html
@@ -3,10 +3,6 @@
 
 @(app: ApplicationDetail, errs: Seq[forms.validation.SectionError])
 
-@formatId(id: Long) = @{
-f"RIFS $id%04d"
-}
-
 @errorClass = @{if(errs.nonEmpty) "rifs-error-panel" else ""}
 
 @main(s"Overview - RIFS", backLink=Some(BackLink("Return to my dashboard", controllers.routes.OpportunityController.wip(routes.StartPageController.startPage().url).url)), displayUserName=Some("Experienced Eric")) {


### PR DESCRIPTION
Proposal for a small formatting change to the RIFS $ID field

Was: `RIFS00001`
Now: `RIFS 0001`

I've spoken to David Hockin about this and we believe it is a small but useful improvement:

* easier to read
* better support for white labelling (e.g. the Arts Council)
* putting a string constant in a db prefix would be nonsense anyway
