### PR TITLE
Feature/1482 duplicate opportunity

### DIFF
--- a/src/main/scala/controllers/manage/OpportunityController.scala
+++ b/src/main/scala/controllers/manage/OpportunityController.scala
@@ -4,18 +4,19 @@ import javax.inject.Inject
 
 import actions.OpportunityAction
 import cats.data.Validated._
-import controllers.FieldCheckHelpers.{FieldHints, hinting, noErrors}
+import controllers.FieldCheckHelpers.hinting
 import controllers._
 import forms.validation.DateTimeRangeValues
 import forms.{DateTimeRangeField, DateValues, TextAreaField, TextField}
 import models._
 import org.joda.time.LocalDate
 import play.api.libs.json._
-import play.api.mvc.{Action, Controller, Result}
+import play.api.mvc.{Action, Controller}
 import services.{ApplicationFormOps, OpportunityOps}
 
 import scala.concurrent.{ExecutionContext, Future}
 
+case class OpportunityLibraryEntry(id: OpportunityId, title: String, status: String, structure: String)
 
 class OpportunityController @Inject()(opportunities: OpportunityOps, appForms: ApplicationFormOps, OpportunityAction: OpportunityAction)(implicit ec: ExecutionContext) extends Controller {
 
@@ -34,8 +35,14 @@ class OpportunityController @Inject()(opportunities: OpportunityOps, appForms: A
     }.getOrElse(Redirect(controllers.manage.routes.OpportunityController.showNewOpportunityForm()))
   }
 
+
+  private def libraryEntry(o: Opportunity): OpportunityLibraryEntry = {
+    val status = o.publishedAt.map(_ => "Open").getOrElse("Unpublished")
+    OpportunityLibraryEntry(o.id, o.title, status, "Responsive, claim, FEC")
+  }
+
   def showOpportunityLibrary = Action.async {
-    opportunities.getOpenOpportunitySummaries.map { os => Ok(views.html.manage.showOpportunityLibrary(os)) }
+    opportunities.getOpportunitySummaries.map { os => Ok(views.html.manage.showOpportunityLibrary(os.map(libraryEntry))) }
   }
 
   def showOverviewPage(id: OpportunityId) = OpportunityAction(id).async { request =>
@@ -67,7 +74,7 @@ class OpportunityController @Inject()(opportunities: OpportunityOps, appForms: A
 
   def editTitle(id: OpportunityId) = OpportunityAction(id) { request =>
     val answers = JsObject(Seq("title" -> Json.toJson(request.opportunity.title)))
-    val hints = hinting (answers, Map(titleField.name -> titleField.check))
+    val hints = hinting(answers, Map(titleField.name -> titleField.check))
     Ok(views.html.manage.editTitleForm(titleField, request.opportunity, titleQuestion, answers, Seq(), hints))
   }
 
@@ -84,7 +91,7 @@ class OpportunityController @Inject()(opportunities: OpportunityOps, appForms: A
 
   val DESCRIPTION = "description"
   val descriptionField = TextAreaField(Some(DESCRIPTION), DESCRIPTION, 501)
-  val descriptionQuestions = Map (DESCRIPTION ->
+  val descriptionQuestions = Map(DESCRIPTION ->
     Question("Be as specific as possible so that applicants fully understand the aim of the opportunity." +
       " This will help ensure that applications meet the criteria and objectives.")
   )
@@ -93,41 +100,44 @@ class OpportunityController @Inject()(opportunities: OpportunityOps, appForms: A
     val hints = FieldCheckHelpers.hinting(initial, Map(DESCRIPTION -> descriptionField.check))
     Ok(views.html.manage.editDescriptionForm(descriptionField, opp, section,
       routes.OpportunityController.editDescription(opp.id, section).url,
-      descriptionQuestions, initial, errs, hints ))
+      descriptionQuestions, initial, errs, hints))
   }
 
   def editDescription(id: OpportunityId, section: Int) = OpportunityAction(id) { request =>
-    request.opportunity.description.find(_.sectionNumber == section ) match {
+    request.opportunity.description.find(_.sectionNumber == section) match {
       case Some(sect) =>
-        val answers = JsObject (Seq (DESCRIPTION -> Json.toJson(sect.text) ) )
+        val answers = JsObject(Seq(DESCRIPTION -> Json.toJson(sect.text)))
         doEditDescription(request.opportunity, section, answers)
       case None => NotFound
     }
   }
 
   val VIEW_OPP_SECTION_FLASH = "VIEW_OPP_SECTION_BACK_URL"
+
   def saveDescription(id: OpportunityId, section: Int) = OpportunityAction(id).async(JsonForm.parser) { implicit request =>
     (request.body.values \ DESCRIPTION).toOption.map { fValue =>
       descriptionField.check(DESCRIPTION, fValue) match {
         case Nil =>
-            opportunities.saveDescriptionSectionText(id, section, Some(fValue.as[String])).map { _ =>
-              request.body.action match {
-                case Save =>
-                  Redirect(controllers.manage.routes.OpportunityController.showOverviewPage(id))
-                case Preview =>
-                  Redirect(controllers.manage.routes.OpportunityController.viewOppSection(id, section))
-                    .flashing(VIEW_OPP_SECTION_FLASH ->
-                              controllers.manage.routes.OpportunityController.editDescription(id,section).url)
-              }
-            }.recover {
-              case e =>
-                val errs = Seq(forms.validation.FieldError("", e.getMessage))
-                doEditDescription(request.opportunity, section, request.body.values, errs)
+          opportunities.saveDescriptionSectionText(id, section, Some(fValue.as[String])).map { _ =>
+            request.body.action match {
+              case Save =>
+                Redirect(controllers.manage.routes.OpportunityController.showOverviewPage(id))
+              case Preview =>
+                Redirect(controllers.manage.routes.OpportunityController.viewOppSection(id, section))
+                  .flashing(VIEW_OPP_SECTION_FLASH ->
+                    controllers.manage.routes.OpportunityController.editDescription(id, section).url)
             }
+          }.recover {
+            case e =>
+              val errs = Seq(forms.validation.FieldError("", e.getMessage))
+              doEditDescription(request.opportunity, section, request.body.values, errs)
+          }
         case errors =>
-          Future { doEditDescription(request.opportunity, section, request.body.values, errors) }
+          Future {
+            doEditDescription(request.opportunity, section, request.body.values, errors)
+          }
       }
-    }.getOrElse( Future.successful(BadRequest) )
+    }.getOrElse(Future.successful(BadRequest))
   }
 
   def viewTitle(id: OpportunityId) = OpportunityAction(id) { request =>
@@ -137,6 +147,7 @@ class OpportunityController @Inject()(opportunities: OpportunityOps, appForms: A
   def viewDescription(id: OpportunityId) = OpportunityAction(id) { request =>
     Ok(views.html.manage.viewDescription(request.opportunity))
   }
+
   def viewGrantValue(id: OpportunityId) = OpportunityAction(id) { request =>
     Ok(views.html.manage.viewGrantValue(request.opportunity))
   }
@@ -145,8 +156,11 @@ class OpportunityController @Inject()(opportunities: OpportunityOps, appForms: A
     Ok(views.html.manage.viewOppSection(request.opportunity, sectionNum, request.flash.get(VIEW_OPP_SECTION_FLASH)))
   }
 
-  def duplicate(opportunityId: OpportunityId) = OpportunityAction(opportunityId) { request =>
-    Ok(views.html.wip(controllers.manage.routes.OpportunityController.showOverviewPage(opportunityId).url))
+  def duplicate(id: OpportunityId) = Action.async { request =>
+    opportunities.duplicate(id).map {
+      case Some(newOppId) => Redirect(controllers.manage.routes.OpportunityController.showOverviewPage(newOppId))
+      case None => NotFound
+    }
   }
 
   def viewDeadlines(id: OpportunityId) = OpportunityAction(id) { request =>

--- a/src/main/scala/models/Opportunity.scala
+++ b/src/main/scala/models/Opportunity.scala
@@ -1,6 +1,6 @@
 package models
 
-import org.joda.time.LocalDate
+import org.joda.time.{DateTime, LocalDate}
 
 object OpportunityDefs {
   val ABOUT_SECTION_NO = 1
@@ -22,9 +22,10 @@ case class Opportunity(
                         startDate: LocalDate,
                         endDate: Option[LocalDate],
                         value: OpportunityValue,
+                        publishedAt:Option[DateTime],
                         description: Seq[OpportunityDescriptionSection]
                       ) {
-  lazy val summary: OpportunitySummary = OpportunitySummary(id, title, startDate, endDate, value)
+  lazy val summary: OpportunitySummary = OpportunitySummary(id, title, startDate, endDate, value, publishedAt)
 }
 
 case class OpportunitySummary(
@@ -32,5 +33,6 @@ case class OpportunitySummary(
                                title: String,
                                startDate: LocalDate,
                                endDate: Option[LocalDate],
-                               value: OpportunityValue
+                               value: OpportunityValue,
+                               publishedAt:Option[DateTime]
                              )

--- a/src/main/scala/models/Opportunity.scala
+++ b/src/main/scala/models/Opportunity.scala
@@ -22,10 +22,11 @@ case class Opportunity(
                         startDate: LocalDate,
                         endDate: Option[LocalDate],
                         value: OpportunityValue,
-                        publishedAt:Option[DateTime],
+                        publishedAt: Option[DateTime],
+                        duplicatedFrom: Option[OpportunityId],
                         description: Seq[OpportunityDescriptionSection]
                       ) {
-  lazy val summary: OpportunitySummary = OpportunitySummary(id, title, startDate, endDate, value, publishedAt)
+  lazy val summary: OpportunitySummary = OpportunitySummary(id, title, startDate, endDate, value, publishedAt, duplicatedFrom)
 }
 
 case class OpportunitySummary(
@@ -34,5 +35,6 @@ case class OpportunitySummary(
                                startDate: LocalDate,
                                endDate: Option[LocalDate],
                                value: OpportunityValue,
-                               publishedAt:Option[DateTime]
+                               publishedAt: Option[DateTime],
+                               duplicatedFrom: Option[OpportunityId]
                              )

--- a/src/main/scala/services/OpportunityOps.scala
+++ b/src/main/scala/services/OpportunityOps.scala
@@ -9,11 +9,15 @@ import scala.concurrent.Future
 trait OpportunityOps {
   def byId(id: OpportunityId): Future[Option[Opportunity]]
 
+  def getOpportunitySummaries: Future[Seq[Opportunity]]
+
   def getOpenOpportunitySummaries: Future[Seq[Opportunity]]
 
   def saveSummary(opp: OpportunitySummary): Future[Unit]
 
   def saveDescriptionSectionText(id: OpportunityId, sectionNo: Int, descSect: Option[String]): Future[Unit]
+
+  def duplicate(id: OpportunityId): Future[Option[OpportunityId]]
 }
 
 

--- a/src/main/scala/services/OpportunityService.scala
+++ b/src/main/scala/services/OpportunityService.scala
@@ -11,6 +11,10 @@ import play.api.libs.ws.WSClient
 import scala.concurrent.{ExecutionContext, Future}
 
 class OpportunityService @Inject()(val ws: WSClient)(implicit val ec: ExecutionContext) extends OpportunityOps with RestService with ValueClassFormats {
+  private val dtPattern = "dd MMM yyyy HH:mm:ss"
+  implicit val dtReads = Reads.jodaDateReads(dtPattern)
+  implicit val dtWrites = Writes.jodaDateWrites(dtPattern)
+
   implicit val jldReads = Reads.jodaLocalDateReads("d MMM yyyy")
   implicit val jldWrites = Writes.jodaLocalDateWrites("d MMM yyyy")
   implicit val odsFmt = Json.format[OpportunityDescriptionSection]
@@ -20,6 +24,11 @@ class OpportunityService @Inject()(val ws: WSClient)(implicit val ec: ExecutionC
   implicit val oppSummaryFmt = Json.format[OpportunitySummary]
 
   val baseUrl = Config.config.business.baseUrl
+
+  override def getOpportunitySummaries: Future[Seq[Opportunity]] = {
+    val url = s"$baseUrl/opportunity/summaries"
+    getMany[Opportunity](url)
+  }
 
   override def getOpenOpportunitySummaries: Future[Seq[Opportunity]] = {
     val url = s"$baseUrl/opportunity/open/summaries"
@@ -39,5 +48,10 @@ class OpportunityService @Inject()(val ws: WSClient)(implicit val ec: ExecutionC
   override def saveDescriptionSectionText(id: OpportunityId, sectionNo: Int, descSect: Option[String]): Future[Unit] = {
     val url = s"$baseUrl/manage/opportunity/${id.id}/description/$sectionNo"
     post(url, descSect.getOrElse(""))
+  }
+
+  override def duplicate(id: OpportunityId) :Future[Option[OpportunityId]] = {
+    val url = s"$baseUrl/opportunity/${id.id}/duplicate"
+    postWithResult[OpportunityId, String](url, "")
   }
 }

--- a/src/main/twirl/views/manage/opportunityOverview.scala.html
+++ b/src/main/twirl/views/manage/opportunityOverview.scala.html
@@ -1,5 +1,4 @@
 @import models._
-@import partials._
 
 @(backUrl:String, opportunity: Opportunity, app: ApplicationForm, tabNumber: Option[Int] = None)
 
@@ -15,6 +14,12 @@ backLink=Some(BackLink("Opportunity library", controllers.manage.routes.Opportun
 <!-- main content -->
 <div class="grid-row">
     <div class="column-two-thirds">
+        @opportunity.duplicatedFrom.map { fromId =>
+            <div>
+                This is a copy of <a href="@controllers.manage.routes.OpportunityController.showOverviewPage(fromId)">@formatId(fromId.id)</a>
+            </div>
+        }
+
         <h1 class="heading-xlarge">
             <span class="heading-secondary">@formatId(opportunity.id.id): @opportunity.title</span>
             Opportunity template

--- a/src/main/twirl/views/manage/showOpportunityLibrary.scala.html
+++ b/src/main/twirl/views/manage/showOpportunityLibrary.scala.html
@@ -1,6 +1,6 @@
-@(os: Seq[Opportunity])
+@(os: Seq[controllers.manage.OpportunityLibraryEntry])
 
-@main("Opportunity list - RIFS", backLink=Some(BackLink("Create new opportunity", controllers.manage.routes.OpportunityController.showNewOpportunityForm().url)), displayUserName=Some("Portfolio Peter")) {
+@main("Opportunity list - RIFS", backLink = Some(BackLink("Create new opportunity", controllers.manage.routes.OpportunityController.showNewOpportunityForm().url)), displayUserName = Some("Portfolio Peter")) {
     <div>
         <h1 class="heading-xlarge">Opportunity library</h1>
 
@@ -17,14 +17,14 @@
                 </tr>
             </thead>
             <tbody>
-                @for((o, i) <- os.zipWithIndex) {
-                    <tr>
-                        <td data-label="Ref.">@("%04d".format(o.id.id))</td>
-                        <td data-label="Title"><a href=@controllers.manage.routes.OpportunityController.showOpportunityPreview(o.id, None).url>@o.title</a></td>
-                        <td data-label="Status">Open</td>
-                        <td data-label="Structure">Responsive, claim, FEC</td>
-                    </tr>
-                }
+            @os.map { o =>
+                <tr>
+                    <td data-label="Ref.">@("%04d".format(o.id.id))</td>
+                    <td data-label="Title"><a href=@controllers.manage.routes.OpportunityController.showOpportunityPreview(o.id, None).url>@o.title</a></td>
+                    <td data-label="Status">@o.status</td>
+                    <td data-label="Structure">@o.structure</td>
+                </tr>
+            }
             </tbody>
         </table>
 

--- a/src/test/scala/views/html/EventAudienceFormSpec.scala
+++ b/src/test/scala/views/html/EventAudienceFormSpec.scala
@@ -34,7 +34,7 @@ class EventAudienceFormSpec extends WordSpecLike with Matchers with OptionValues
       ApplicationId(1),
       1,
       1,
-      OpportunitySummary(OpportunityId(1), "Research priorities in health care", new LocalDate(), None, OpportunityValue(0, "")),
+      OpportunitySummary(OpportunityId(1), "Research priorities in health care", new LocalDate(), None, OpportunityValue(0, ""), None),
       fs,
       None)
 

--- a/src/test/scala/views/html/EventAudienceFormSpec.scala
+++ b/src/test/scala/views/html/EventAudienceFormSpec.scala
@@ -34,7 +34,7 @@ class EventAudienceFormSpec extends WordSpecLike with Matchers with OptionValues
       ApplicationId(1),
       1,
       1,
-      OpportunitySummary(OpportunityId(1), "Research priorities in health care", new LocalDate(), None, OpportunityValue(0, ""), None),
+      OpportunitySummary(OpportunityId(1), "Research priorities in health care", new LocalDate(), None, OpportunityValue(0, ""), None, None),
       fs,
       None)
 


### PR DESCRIPTION
Wired in the Duplicate Opportunity button and updated the Opportunity Library to show all opportunities, not just open ones.

This relies on changes from https://github.com/UKGovernmentBEIS/rifs-business/pull/34

For the moment I've made no attempt to re-wire the links on the Set Up or Questions tabs as I think these are covered by other Jira cases.

@jon-shipley the div at the top of the overview page that says "This is a copy of" needs styling.