### PR TITLE
Changed the `reset` button on the landing page to use the new `/reset…

### DIFF
--- a/src/main/scala/controllers/ApplicationController.scala
+++ b/src/main/scala/controllers/ApplicationController.scala
@@ -35,7 +35,7 @@ class ApplicationController @Inject()(
   }
 
   def reset = Action.async {
-    applications.deleteAll().map(_ => Redirect(controllers.routes.StartPageController.startPage()))
+    applications.reset().map(_ => Redirect(controllers.routes.StartPageController.startPage()))
   }
 
   import FieldCheckHelpers._

--- a/src/main/scala/services/ApplicationOps.scala
+++ b/src/main/scala/services/ApplicationOps.scala
@@ -20,7 +20,7 @@ trait ApplicationOps {
 
   def sectionDetail(id: ApplicationId, sectionNum:Int): Future[Option[ApplicationSectionDetail]]
 
-  def deleteAll(): Future[Unit]
+  def reset(): Future[Unit]
 
   def saveSection(id: ApplicationId, sectionNumber: Int, doc: JsObject): Future[Unit]
 

--- a/src/main/scala/services/ApplicationService.scala
+++ b/src/main/scala/services/ApplicationService.scala
@@ -124,9 +124,9 @@ class ApplicationService @Inject()(val ws: WSClient)(implicit val ec: ExecutionC
     getOpt[ApplicationSectionDetail](url)
   }
 
-  override def deleteAll(): Future[Unit] = {
-    val url = s"$baseUrl/application"
-    delete(url)
+  override def reset(): Future[Unit] = {
+    val url = s"$baseUrl/reset"
+    post(url, None)
   }
 
   override def deleteSection(id: ApplicationId, sectionNumber: Int): Future[Unit] = {


### PR DESCRIPTION
…` endpoint on the backend so that not only are all the applications deleted, but so are all opportunities other than the starting one.