### PR TITLE
Refactor/normalised validation values

### DIFF
--- a/src/main/scala/forms/DateField.scala
+++ b/src/main/scala/forms/DateField.scala
@@ -2,9 +2,8 @@ package forms
 
 import controllers.{FieldCheck, FieldChecks, JsonHelpers}
 import forms.validation.{DateFieldValidator, FieldError, FieldHint}
-import models.{ApplicationSectionDetail, Question}
+import models.Question
 import play.api.libs.json.{JsObject, Json}
-import play.twirl.api.Html
 
 case class DateValues(day: Option[String], month: Option[String], year: Option[String])
 

--- a/src/main/scala/forms/validation/CostItemValidator.scala
+++ b/src/main/scala/forms/validation/CostItemValidator.scala
@@ -18,7 +18,7 @@ case object CostItemValidator extends FieldValidator[CostItemValues, CostItem] {
   val costValidator = CurrencyValidator.anyValue
   val justificationValidator = MandatoryValidator(Some("justification")).andThen(WordCountValidator(200))
 
-  override def validate(path: String, a: CostItemValues): ValidatedNel[FieldError, CostItem] = {
+  override def doValidation(path: String, a: Normalised[CostItemValues]): ValidatedNel[FieldError, CostItem] = {
     val itemV = itemValidator.validate(s"$path.itemName", a.itemName)
     val costV = costValidator.validate(s"$path.cost", a.cost)
     val justV = justificationValidator.validate(s"$path.justification", a.justification)
@@ -34,18 +34,18 @@ case object CostItemValidator extends FieldValidator[CostItemValues, CostItem] {
 
 case class CostSectionValidator(maxValue: BigDecimal) extends FieldValidator[CostList, List[CostItem]] {
   val nonEmptyV = new FieldValidator[List[CostItem], List[CostItem]] {
-    override def validate(path: String, items: List[CostItem]): ValidatedNel[FieldError, List[CostItem]] =
+    override def doValidation(path: String, items: Normalised[List[CostItem]]): ValidatedNel[FieldError, List[CostItem]] =
       if (items.isEmpty) FieldError(path, s"Must provide at least one item.").invalidNel
       else items.validNel
   }
 
   val notTooCostlyV = new FieldValidator[List[CostItem], List[CostItem]] {
-    override def validate(path: String, items: List[CostItem]): ValidatedNel[FieldError, List[CostItem]] =
+    override def doValidation(path: String, items: Normalised[List[CostItem]]): ValidatedNel[FieldError, List[CostItem]] =
       if (items.map(_.cost).sum > maxValue) FieldError(path, s"Total requested exceeds limit. Please check costs of items.").invalidNel
       else items.validNel
   }
 
-  override def validate(path: String, cvs: CostList): ValidatedNel[FieldError, List[CostItem]] = {
+  override def doValidation(path: String, cvs: Normalised[CostList]): ValidatedNel[FieldError, List[CostItem]] = {
     nonEmptyV.andThen(notTooCostlyV).validate("", cvs.items)
   }
 }

--- a/src/main/scala/forms/validation/CurrencyValidator.scala
+++ b/src/main/scala/forms/validation/CurrencyValidator.scala
@@ -7,15 +7,17 @@ import scala.util.Try
 
 object CurrencyValidator {
   def apply() = new CurrencyValidator(None)
+
   def apply(minValue: BigDecimal) = new CurrencyValidator(Some(minValue))
-  final val greaterThanZero = apply( BigDecimal(0.0) )
+
+  final val greaterThanZero = apply(BigDecimal(0.0))
   final val anyValue = apply()
 }
 
 class CurrencyValidator(minValue: Option[BigDecimal]) extends FieldValidator[Option[String], BigDecimal] {
   override def normalise(os: Option[String]): Option[String] = os.map(_.trim().replaceAll(",", ""))
 
-  override def validate(path: String, value: Option[String]): ValidatedNel[FieldError, BigDecimal] = {
+  override def doValidation(path: String, value: Normalised[Option[String]]): ValidatedNel[FieldError, BigDecimal] = {
     Try(BigDecimal(normalise(value).getOrElse("")).setScale(2, BigDecimal.RoundingMode.HALF_UP)).toOption match {
       case Some(bd) => minValue match {
         case Some(min) if bd <= min => FieldError(path, s"The value must be greater than $min").invalidNel

--- a/src/main/scala/forms/validation/DateFieldValidator.scala
+++ b/src/main/scala/forms/validation/DateFieldValidator.scala
@@ -15,19 +15,18 @@ object DateFieldValidator {
   val mustBeTodayOrLaterMsg = "Must be today or later"
 }
 
+
 case class DateFieldValidator(allowPast: Boolean) extends FieldValidator[DateValues, LocalDate] {
 
   import DateFieldValidator._
 
-  override def normalise(vs: DateValues): DateValues = vs.copy(
-    day = vs.day.map(_.trim()),
-    month = vs.month.map(_.trim()),
-    year = vs.year.map(_.trim())
-  )
+  override def normalise(vs: DateValues): DateValues =
+    vs.copy(day = vs.day.map(_.trim()), month = vs.month.map(_.trim()), year = vs.year.map(_.trim()))
 
-  def mandatoryInt(path: String, s: Option[String], displayName: String): ValidatedNel[FieldError, Int] = MandatoryValidator(Some(displayName)).validate(path, s).andThen(IntValidator().validate(path, _))
+  def mandatoryInt(path: String, s: Option[String], displayName: String): ValidatedNel[FieldError, Int] =
+    MandatoryValidator(Some(displayName)).validate(path, s).andThen(IntValidator().validate(path, _))
 
-  def validateDMY(path: String, vs: DateValues): ValidatedNel[FieldError, DMY] = {
+  def validateDMY(path: String, vs: Normalised[DateValues]): ValidatedNel[FieldError, DMY] = {
     (mandatoryInt(s"$path.day", vs.day, "day") |@|
       mandatoryInt(s"$path.month", vs.month, "month") |@|
       mandatoryInt(s"$path.year", vs.year, "year")).tupled
@@ -45,6 +44,6 @@ case class DateFieldValidator(allowPast: Boolean) extends FieldValidator[DateVal
     if (!allowPast && ld.isBefore(LocalDate.now())) FieldError(path, mustBeTodayOrLaterMsg).invalidNel
     else ld.valid
 
-  override def validate(path: String, vs: DateValues): ValidatedNel[FieldError, LocalDate] =
-    validateDMY(path, normalise(vs)).andThen(validateDate(path, _)).andThen(validatePastDate(path, _))
+  override def doValidation(path: String, vs: Normalised[DateValues]): ValidatedNel[FieldError, LocalDate] =
+    validateDMY(path, vs).andThen(validateDate(path, _)).andThen(validatePastDate(path, _))
 }

--- a/src/main/scala/forms/validation/DateFieldValidator.scala
+++ b/src/main/scala/forms/validation/DateFieldValidator.scala
@@ -41,13 +41,10 @@ case class DateFieldValidator(allowPast: Boolean) extends FieldValidator[DateVal
       case None => FieldError(path, mustProvideAValidDateMsg).invalidNel
     }
 
-  def validatePastDate(path: String, ld: LocalDate): ValidatedNel[FieldError, LocalDate] = {
+  def validatePastDate(path: String, ld: LocalDate): ValidatedNel[FieldError, LocalDate] =
     if (!allowPast && ld.isBefore(LocalDate.now())) FieldError(path, mustBeTodayOrLaterMsg).invalidNel
     else ld.valid
-  }
 
-  override def validate(path: String, vs: DateValues): ValidatedNel[FieldError, LocalDate] = {
-    validateDMY(path, vs).andThen(validateDate(path, _)).andThen(validatePastDate(path, _))
-  }
-
+  override def validate(path: String, vs: DateValues): ValidatedNel[FieldError, LocalDate] =
+    validateDMY(path, normalise(vs)).andThen(validateDate(path, _)).andThen(validatePastDate(path, _))
 }

--- a/src/main/scala/forms/validation/DateFieldValidator.scala
+++ b/src/main/scala/forms/validation/DateFieldValidator.scala
@@ -8,6 +8,8 @@ import org.joda.time.LocalDate
 
 import scala.util.Try
 
+case class DMY(day: Int, month: Int, year: Int)
+
 object DateFieldValidator {
   val mustProvideAValidDateMsg = "Must provide a valid date"
   val mustBeTodayOrLaterMsg = "Must be today or later"
@@ -25,22 +27,27 @@ case class DateFieldValidator(allowPast: Boolean) extends FieldValidator[DateVal
 
   def mandatoryInt(path: String, s: Option[String], displayName: String): ValidatedNel[FieldError, Int] = MandatoryValidator(Some(displayName)).validate(path, s).andThen(IntValidator().validate(path, _))
 
-  def validateDate(path: String, d: Int, m: Int, y: Int): ValidatedNel[FieldError, LocalDate] =
-    Try(new LocalDate(y, m, d)).toOption match {
-      case Some(ld) if !allowPast && ld.isBefore(LocalDate.now()) => FieldError(path, mustBeTodayOrLaterMsg).invalidNel
+  def validateDMY(path: String, vs: DateValues): ValidatedNel[FieldError, DMY] = {
+    (mandatoryInt(s"$path.day", vs.day, "day") |@|
+      mandatoryInt(s"$path.month", vs.month, "month") |@|
+      mandatoryInt(s"$path.year", vs.year, "year")).tupled
+      .map { case (d, m, y) => DMY(d, m, y) }
+      .leftMap(_ => NonEmptyList.of(FieldError(s"$path", mustProvideAValidDateMsg)))
+  }
+
+  def validateDate(path: String, dmy: DMY): ValidatedNel[FieldError, LocalDate] =
+    Try(new LocalDate(dmy.year, dmy.month, dmy.day)).toOption match {
       case Some(ld) => ld.valid
       case None => FieldError(path, mustProvideAValidDateMsg).invalidNel
     }
 
+  def validatePastDate(path: String, ld: LocalDate): ValidatedNel[FieldError, LocalDate] = {
+    if (!allowPast && ld.isBefore(LocalDate.now())) FieldError(path, mustBeTodayOrLaterMsg).invalidNel
+    else ld.valid
+  }
+
   override def validate(path: String, vs: DateValues): ValidatedNel[FieldError, LocalDate] = {
-    val validatedInts: ValidatedNel[FieldError, (Int, Int, Int)] =
-      (mandatoryInt(s"$path.day", vs.day, "day") |@|
-        mandatoryInt(s"$path.month", vs.month, "month") |@|
-        mandatoryInt(s"$path.year", vs.year, "year"))
-        .tupled.leftMap { v =>
-        NonEmptyList.of(FieldError(s"$path", mustProvideAValidDateMsg))
-      }
-    validatedInts.andThen { case (d, m, y) => validateDate(path, d, m, y) }
+    validateDMY(path, vs).andThen(validateDate(path, _)).andThen(validatePastDate(path, _))
   }
 
 }

--- a/src/main/scala/forms/validation/DateWithDaysValidator.scala
+++ b/src/main/scala/forms/validation/DateWithDaysValidator.scala
@@ -14,7 +14,7 @@ case class DateWithDaysValidator(allowPast: Boolean, minValue: Int, maxValue: In
   val dateValidator = DateFieldValidator(allowPast)
   val daysValidator = IntValidator(minValue, maxValue)
 
-  override def validate(path: String, vs: DateWithDaysValues): ValidatedNel[FieldError, DateWithDays] = {
+  override def doValidation(path: String, vs: Normalised[DateWithDaysValues]): ValidatedNel[FieldError, DateWithDays] = {
     val dv: DateValues = vs.date.getOrElse(DateValues(None, None, None))
     val days: String = vs.days.getOrElse("")
 

--- a/src/main/scala/forms/validation/FieldValidator.scala
+++ b/src/main/scala/forms/validation/FieldValidator.scala
@@ -2,6 +2,8 @@ package forms.validation
 
 import cats.data.ValidatedNel
 import play.api.libs.json.JsValue
+import shapeless.tag
+import shapeless.tag.@@
 
 case class FieldError(path: String, err: String)
 
@@ -10,17 +12,33 @@ case class FieldHint(path: String, hint: String, matchingJsType: Option[String] 
 trait FieldValidator[A, B] {
   outer =>
 
+  sealed trait NormalisedTag
+
+  type Normalised[T] = T @@ NormalisedTag
+
   /**
-    * Provide a way for the validator to normalise the input value.
+    * Provide a way for the validator to normalise the input value. To keep things simple for the validator
+    * implementation this returns an `A` rather than a `Normalised[A]` and the `validate` method does the
+    * tagging.
     */
   def normalise(a: A): A = a
 
-  def validate(path: String, a: A): ValidatedNel[FieldError, B]
+  /**
+    * Sometimes the type tag confuses the compiler, usually in `match` expressions. This
+    * convenience function strips the tag from the normalised value for those situations.
+    */
+  final def denormal(a: Normalised[A]): A = a
+
+  private def normal(a: A): Normalised[A] = tag[NormalisedTag](a)
+
+  final def validate(path: String, a: A): ValidatedNel[FieldError, B] = doValidation(path, normal(normalise(a)))
+
+  protected def doValidation(path: String, a: Normalised[A]): ValidatedNel[FieldError, B]
 
   def hintText(path: String, jv: JsValue): List[FieldHint] = List()
 
   def andThen[C](v2: FieldValidator[B, C]): FieldValidator[A, C] = new FieldValidator[A, C] {
-    override def validate(path: String, a: A): ValidatedNel[FieldError, C] = outer.validate(path, a).andThen(v2.validate(path, _))
+    override def doValidation(path: String, a: Normalised[A]): ValidatedNel[FieldError, C] = outer.validate(path, a).andThen(v2.validate(path, _))
 
     override def hintText(path: String, jv: JsValue): List[FieldHint] = v2.hintText(path, jv) ++ outer.hintText(path, jv)
   }

--- a/src/main/scala/forms/validation/FieldValidator.scala
+++ b/src/main/scala/forms/validation/FieldValidator.scala
@@ -2,8 +2,7 @@ package forms.validation
 
 import cats.data.ValidatedNel
 import play.api.libs.json.JsValue
-import shapeless.tag
-import shapeless.tag.@@
+import shapeless.tag._
 
 case class FieldError(path: String, err: String)
 
@@ -29,7 +28,7 @@ trait FieldValidator[A, B] {
     */
   final def denormal(a: Normalised[A]): A = a
 
-  private def normal(a: A): Normalised[A] = tag[NormalisedTag](a)
+  private def normal(a: A): Normalised[A] = a.asInstanceOf[A @@ NormalisedTag]
 
   final def validate(path: String, a: A): ValidatedNel[FieldError, B] = doValidation(path, normal(normalise(a)))
 

--- a/src/main/scala/forms/validation/IntValidator.scala
+++ b/src/main/scala/forms/validation/IntValidator.scala
@@ -12,8 +12,8 @@ object ParseInt {
 case class IntValidator(minValue: Int = Int.MinValue, maxValue: Int = Int.MaxValue) extends FieldValidator[String, Int] {
   override def normalise(s: String): String = s.trim()
 
-  override def validate(path: String, s: String): ValidatedNel[FieldError, Int] = {
-    normalise(s) match {
+  override def doValidation(path: String, s: Normalised[String]): ValidatedNel[FieldError, Int] = {
+    s match {
       case ParseInt(i) if i < minValue => FieldError(path, s"Minimum value is $minValue").invalidNel
       case ParseInt(i) if i > maxValue => FieldError(path, s"Maximum value is $maxValue").invalidNel
       case ParseInt(i) => i.validNel

--- a/src/main/scala/forms/validation/MandatoryValidator.scala
+++ b/src/main/scala/forms/validation/MandatoryValidator.scala
@@ -6,9 +6,9 @@ import cats.syntax.validated._
 case class MandatoryValidator(displayName: Option[String] = None) extends FieldValidator[Option[String], String] {
   override def normalise(os: Option[String]): Option[String] = os.map(_.trim())
 
-  override def validate(path: String, s: Option[String]): ValidatedNel[FieldError, String] = {
+  override def doValidation(path: String, so: Normalised[Option[String]]): ValidatedNel[FieldError, String] = {
     val fieldName = displayName.map(n => s"'$n'").getOrElse("Field")
-    normalise(s) match {
+    denormal(so) match {
       case None | Some("") => FieldError(path, s"$fieldName cannot be empty").invalidNel
       case Some(n) => n.validNel
     }

--- a/src/main/scala/forms/validation/WordCountValidator.scala
+++ b/src/main/scala/forms/validation/WordCountValidator.scala
@@ -10,7 +10,7 @@ case class WordCountValidator(maxWords: Int) extends FieldValidator[String, Stri
 
   override def normalise(s: String): String = s.trim()
 
-  override def validate(path: String, s: String): ValidatedNel[FieldError, String] = {
+  override def doValidation(path: String, s: Normalised[String]): ValidatedNel[FieldError, String] = {
     normalise(s) match {
       case n if n.split("\\s+").length > maxWords => FieldError(path, "Word limit exceeded").invalidNel
       case n => n.validNel

--- a/src/test/scala/forms/validation/DateFieldValidatorTest.scala
+++ b/src/test/scala/forms/validation/DateFieldValidatorTest.scala
@@ -51,5 +51,11 @@ class DateFieldValidatorTest extends WordSpecLike with Matchers {
         errs => fail(s"Unexpected errors were produced: $errs")
       }
     }
+
+    "produce no errors when date fields are valid after normalisation and any date is allowed" in {
+      DateFieldValidator(true).validate("test", DateValues(Some(" 30 "), Some(" 6"), Some("2016 "))).leftMap {
+        errs => fail(s"Unexpected errors were produced: $errs")
+      }
+    }
   }
 }

--- a/src/test/scala/forms/validation/DateFieldValidatorTest.scala
+++ b/src/test/scala/forms/validation/DateFieldValidatorTest.scala
@@ -1,0 +1,55 @@
+package forms.validation
+
+import forms.DateValues
+import org.scalatest.{Matchers, WordSpecLike}
+
+class DateFieldValidatorTest extends WordSpecLike with Matchers {
+  import DateFieldValidator._
+
+  "validate" should {
+    "give a single error message about an invalid date when fields are missing" in {
+      DateFieldValidator(true).validate("test", DateValues(None, None, None)).map {
+        _=> fail(s"No error messages were produced!")
+      }.leftMap { errs =>
+        errs.tail.length shouldBe 0
+        errs.head.path shouldBe "test"
+        errs.head.err shouldBe mustProvideAValidDateMsg
+      }
+    }
+
+    "give a single error message about an invalid date when fields are blank" in {
+      DateFieldValidator(true).validate("test", DateValues(Some(""), Some(""), Some(""))).map {
+        _=> fail(s"No error messages were produced!")
+      }.leftMap { errs =>
+        errs.tail.length shouldBe 0
+        errs.head.path shouldBe "test"
+        errs.head.err shouldBe mustProvideAValidDateMsg
+      }
+    }
+     "give a single error message about an invalid date when fields valid ints but don't form a valid date" in {
+      DateFieldValidator(true).validate("test", DateValues(Some("31"), Some("6"), Some("2017"))).map {
+        _=> fail(s"No error messages were produced!")
+      }.leftMap { errs =>
+        errs.tail.length shouldBe 0
+        errs.head.path shouldBe "test"
+        errs.head.err shouldBe mustProvideAValidDateMsg
+      }
+    }
+
+    "produce an error when date fields are valid but date is in past" in {
+      DateFieldValidator(false).validate("test", DateValues(Some("30"), Some("6"), Some("2016"))).map {
+        _=> fail(s"No error messages were produced!")
+      }.leftMap { errs =>
+        errs.tail.length shouldBe 0
+        errs.head.path shouldBe "test"
+        errs.head.err shouldBe mustBeTodayOrLaterMsg
+      }
+    }
+
+    "produce no errors when date fields are valid and any date is allowed" in {
+      DateFieldValidator(true).validate("test", DateValues(Some("30"), Some("6"), Some("2016"))).leftMap {
+        errs => fail(s"Unexpected errors were produced: $errs")
+      }
+    }
+  }
+}


### PR DESCRIPTION
Some changes to the `FieldValidator` to ensure that values are normalised as part of the validation. This makes use of Shapeless type tags, but I've tried to hide that as much as possible in the base trait and make it easy to use in the implementations.