### PR TITLE
Spike/refined

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,10 @@ import sbtbuildinfo.BuildInfoPlugin.autoImport._
 
 name := "rifs-frontend-play"
 
+startYear := Some(2016)
+
+organization := "uk.gov.beis.digital"
+
 scalaVersion := "2.11.8"
 
 lazy val `rifs-frontend-play` = (project in file("."))

--- a/build.sbt
+++ b/build.sbt
@@ -13,6 +13,8 @@ lazy val `rifs-frontend-play` = (project in file("."))
 
 git.useGitDescribe := true
 
+scalacOptions ++= Seq("-feature")
+
 routesImport ++= Seq(
   "models._",
   "models.PlayBindings._",

--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,8 @@ routesImport ++= Seq(
   "models._",
   "models.PlayBindings._",
   "controllers._",
-  "com.wellfactored.playbindings.ValueClassUrlBinders._"
+  "com.wellfactored.playbindings.ValueClassUrlBinders._",
+  "controllers.RefinedBinders._"
 )
 
 buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion)
@@ -43,6 +44,8 @@ libraryDependencies ++= Seq(
   "com.wellfactored" %% "play-bindings" % "1.1.0",
   "com.beachape" %% "enumeratum" % "1.5.2",
   "com.beachape" %% "enumeratum-play-json" % "1.5.2",
+  "eu.timepit" %% "refined" % "0.6.1",
+  "com.lunaryorn" %% "play-json-refined" % "0.1",
 
   "org.scalatestplus.play" %% "scalatestplus-play" % "1.5.1" % Test,
   "org.jsoup" % "jsoup" % "1.9.2" % Test

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.9")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.10")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.2.0-M5")
 

--- a/src/main/resources/routes
+++ b/src/main/resources/routes
@@ -10,29 +10,29 @@ GET         /                                                         controller
 GET         /opportunities                                            controllers.OpportunityController.showOpportunities
 
 GET         /opportunities/guidance/:opportunityId                    controllers.OpportunityController.showGuidancePage(opportunityId:OpportunityId)
-GET         /opportunity/:opportunityId                               controllers.OpportunityController.showOpportunity(opportunityId:OpportunityId, section:Option[Int])
-GET         /opportunity/:id/section/:num                             controllers.OpportunityController.showOpportunitySection(id:OpportunityId, num:Int)
+GET         /opportunity/:opportunityId                               controllers.OpportunityController.showOpportunity(opportunityId:OpportunityId, section:Option[OppSectionNumber])
+GET         /opportunity/:id/section/:num                             controllers.OpportunityController.showOpportunitySection(id:OpportunityId, num:OppSectionNumber)
 
 GET         /application_form/:id/apply                               controllers.ApplicationController.showOrCreateForForm(id: ApplicationFormId)
 
 GET         /application/:id                                          controllers.ApplicationController.show(id: ApplicationId)
 POST        /application/:id                                          controllers.ApplicationController.submit(id: ApplicationId)
 
-GET         /application/:id/section/:num                             controllers.ApplicationController.showSectionForm(id: ApplicationId, num:Int)
-POST        /application/:id/section/:num                             controllers.ApplicationController.postSection(id: ApplicationId, num:Int)
-GET         /application/:id/section/:num/edit                        controllers.ApplicationController.editSectionForm(id: ApplicationId, num:Int)
-POST        /application/:id/section/:num/edit                        controllers.ApplicationController.resetAndEditSection(id: ApplicationId, num:Int)
+GET         /application/:id/section/:num                             controllers.ApplicationController.showSectionForm(id: ApplicationId, num:AppSectionNumber)
+POST        /application/:id/section/:num                             controllers.ApplicationController.postSection(id: ApplicationId, num:AppSectionNumber)
+GET         /application/:id/section/:num/edit                        controllers.ApplicationController.editSectionForm(id: ApplicationId, num:AppSectionNumber)
+POST        /application/:id/section/:num/edit                        controllers.ApplicationController.resetAndEditSection(id: ApplicationId, num:AppSectionNumber)
 GET         /application/:id/personal-ref/edit                        controllers.ApplicationController.editPersonalRef(id: ApplicationId)
 POST        /application/:id/personal-ref                             controllers.ApplicationController.savePersonalRef(id: ApplicationId)
 
-GET         /application/:id/section/:num/preview                     controllers.ApplicationPreviewController.previewSection(id: ApplicationId, num:Int)
+GET         /application/:id/section/:num/preview                     controllers.ApplicationPreviewController.previewSection(id: ApplicationId, num:AppSectionNumber)
 GET         /application/:id/preview                                  controllers.ApplicationPreviewController.applicationPreview(id: ApplicationId)
 
-GET         /application/:id/section/:num/add-item                    controllers.CostController.addItem(id:ApplicationId, num: Int)
-POST        /application/:id/section/:num/item                        controllers.CostController.createItem(id:ApplicationId, num: Int)
-POST        /application/:id/section/:num/item/:itemNum               controllers.CostController.saveItem(id:ApplicationId, num: Int, itemNum: Int)
-GET         /application/:id/section/:num/item/:itemNum/delete        controllers.CostController.deleteItem(id:ApplicationId, num: Int, itemNum: Int)
-GET         /application/:id/section/:num/item/:itemNum/edit          controllers.CostController.editItem(id:ApplicationId, num: Int, itemNum: Int)
+GET         /application/:id/section/:num/add-item                    controllers.CostController.addItem(id:ApplicationId, num: AppSectionNumber)
+POST        /application/:id/section/:num/item                        controllers.CostController.createItem(id:ApplicationId, num: AppSectionNumber)
+POST        /application/:id/section/:num/item/:itemNum               controllers.CostController.saveItem(id:ApplicationId, num: AppSectionNumber, itemNum: Int)
+GET         /application/:id/section/:num/item/:itemNum/delete        controllers.CostController.deleteItem(id:ApplicationId, num: AppSectionNumber, itemNum: Int)
+GET         /application/:id/section/:num/item/:itemNum/edit          controllers.CostController.editItem(id:ApplicationId, num: AppSectionNumber, itemNum: Int)
 
 GET         /reset                                                    controllers.ApplicationController.reset
 GET         /wip                                                      controllers.OpportunityController.wip(backUrl: String)
@@ -41,7 +41,7 @@ GET         /wip                                                      controller
 GET         /manage/opportunity/new                                   controllers.manage.OpportunityController.showNewOpportunityForm
 GET         /manage/opportunity/choose                                controllers.manage.OpportunityController.chooseHowToCreateOpportunity(choice:Option[String])
 GET         /manage/opportunities/library                             controllers.manage.OpportunityController.showOpportunityLibrary
-GET         /manage/opportunity/:id                                   controllers.manage.OpportunityController.showOpportunityPreview(id:OpportunityId, section:Option[Int])
+GET         /manage/opportunity/:id                                   controllers.manage.OpportunityController.showOpportunityPreview(id:OpportunityId, section:Option[OppSectionNumber])
 GET         /manage/opportunities/guidance                            controllers.manage.OpportunityController.showPMGuidancePage(backUrl: String)
 
 GET         /manage/opportunity/:id/deadlines                         controllers.manage.DeadlineController.view(id: OpportunityId)
@@ -54,7 +54,7 @@ POST        /manage/opportunity/:id/title                             controller
 GET         /manage/opportunity/:id/title/edit                        controllers.manage.TitleController.edit(id: OpportunityId)
 GET         /manage/opportunity/:id/title/preview                     controllers.manage.TitleController.preview(id: OpportunityId)
 
-GET         /manage/opportunity/:id/section/:num/questions            controllers.manage.OpportunityController.viewQuestions(id: OpportunityId, num:Int)
+GET         /manage/opportunity/:id/section/:num/questions            controllers.manage.OpportunityController.viewQuestions(id: OpportunityId, num:AppSectionNumber)
 
 
 GET         /manage/opportunity/:id/grantvalue                        controllers.manage.GrantValueController.view(id:OpportunityId)
@@ -62,17 +62,17 @@ POST        /manage/opportunity/:id/grantvalue                        controller
 GET         /manage/opportunity/:id/grantvalue/edit                   controllers.manage.GrantValueController.edit(id:OpportunityId)
 GET         /manage/opportunity/:id/grantvalue/preview                controllers.manage.GrantValueController.preview(id:OpportunityId)
 
-GET         /manage/opportunity/:id/section/:num                      controllers.manage.OppSectionController.view(id:OpportunityId, num:Int)
-POST        /manage/opportunity/:id/section/:num                      controllers.manage.OppSectionController.save(id:OpportunityId, num:Int)
-GET         /manage/opportunity/:id/section/:num/edit                 controllers.manage.OppSectionController.edit(id:OpportunityId, num:Int)
-GET         /manage/opportunity/:id/section/:sectionid/preview        controllers.manage.OppSectionController.preview(id: OpportunityId, sectionid:Int)
+GET         /manage/opportunity/:id/section/:num                      controllers.manage.OppSectionController.view(id:OpportunityId, num:OppSectionNumber)
+POST        /manage/opportunity/:id/section/:num                      controllers.manage.OppSectionController.save(id:OpportunityId, num:OppSectionNumber)
+GET         /manage/opportunity/:id/section/:num/edit                 controllers.manage.OppSectionController.edit(id:OpportunityId, num:OppSectionNumber)
+GET         /manage/opportunity/:id/section/:num/preview              controllers.manage.OppSectionController.preview(id: OpportunityId, num:OppSectionNumber)
 
 GET         /manage/opportunity/:id/overview                          controllers.manage.OpportunityController.showOverviewPage(id:OpportunityId)
 POST        /manage/opportunity/:id/duplicate                         controllers.manage.OpportunityController.duplicate(id:OpportunityId)
 POST        /manage/opportunity/:id/publish                           controllers.manage.OpportunityController.publish(id:OpportunityId)
 
 
-GET         /manage/opportunity/:id/preview                           controllers.manage.OpportunityController.showOpportunityPublishPreview(id: OpportunityId, section:Option[Int])
+GET         /manage/opportunity/:id/preview                           controllers.manage.OpportunityController.showOpportunityPublishPreview(id: OpportunityId, section:Option[OppSectionNumber])
 
 
 # Health check

--- a/src/main/scala/actions/AppSectionAction.scala
+++ b/src/main/scala/actions/AppSectionAction.scala
@@ -19,7 +19,7 @@ package actions
 
 import javax.inject.Inject
 
-import models.{ApplicationId, ApplicationSectionDetail}
+import models.{ApplicationId, ApplicationSectionDetail, AppSectionNumber}
 import play.api.mvc.Results._
 import play.api.mvc._
 import services.ApplicationOps
@@ -29,7 +29,7 @@ import scala.concurrent.{ExecutionContext, Future}
 case class AppSectionRequest[A](appSection: ApplicationSectionDetail, request: Request[A]) extends WrappedRequest[A](request)
 
 class AppSectionAction @Inject()(applications: ApplicationOps)(implicit ec: ExecutionContext) {
-  def apply(id: ApplicationId, sectionNum: Int): ActionBuilder[AppSectionRequest] =
+  def apply(id: ApplicationId, sectionNum: AppSectionNumber): ActionBuilder[AppSectionRequest] =
     new ActionBuilder[AppSectionRequest] {
       override def invokeBlock[A](request: Request[A], next: (AppSectionRequest[A]) => Future[Result]): Future[Result] = {
         applications.sectionDetail(id, sectionNum).flatMap {

--- a/src/main/scala/actions/OppSectionAction.scala
+++ b/src/main/scala/actions/OppSectionAction.scala
@@ -19,7 +19,7 @@ package actions
 
 import javax.inject.Inject
 
-import models.{Opportunity, OpportunityDescriptionSection, OpportunityId}
+import models.{OppSectionNumber, Opportunity, OpportunityDescriptionSection, OpportunityId}
 import play.api.mvc.Results.NotFound
 import play.api.mvc.{ActionBuilder, Request, Result, WrappedRequest}
 import services.OpportunityOps
@@ -29,7 +29,7 @@ import scala.concurrent.{ExecutionContext, Future}
 case class OppSectionRequest[A](opportunity: Opportunity, section: OpportunityDescriptionSection, request: Request[A]) extends WrappedRequest[A](request)
 
 class OppSectionAction @Inject()(opportunities: OpportunityOps)(implicit ec: ExecutionContext) {
-  def apply(id: OpportunityId, sectionNum: Int): ActionBuilder[OppSectionRequest] =
+  def apply(id: OpportunityId, sectionNum: OppSectionNumber): ActionBuilder[OppSectionRequest] =
     new ActionBuilder[OppSectionRequest] {
       override def invokeBlock[A](request: Request[A], next: (OppSectionRequest[A]) => Future[Result]): Future[Result] = {
         opportunities.byId(id).flatMap {

--- a/src/main/scala/controllers/ActionHandler.scala
+++ b/src/main/scala/controllers/ActionHandler.scala
@@ -105,7 +105,7 @@ class ActionHandler @Inject()(applications: ApplicationOps, applicationForms: Ap
     } else Future.successful(redisplaySectionForm(app, answers, previewCheckErrs))
   }
 
-  def redirectToPreview(id: ApplicationId, sectionNumber: Int) =
+  def redirectToPreview(id: ApplicationId, sectionNumber: AppSectionNumber) =
     Redirect(routes.ApplicationPreviewController.previewSection(id, sectionNumber))
 
   def renderSectionForm(app: ApplicationSectionDetail,

--- a/src/main/scala/controllers/ApplicationController.scala
+++ b/src/main/scala/controllers/ApplicationController.scala
@@ -20,8 +20,9 @@ package controllers
 import javax.inject.Inject
 
 import actions.{AppDetailAction, AppSectionAction}
+import eu.timepit.refined.auto._
 import forms.TextField
-import forms.validation.{FieldError, SectionError}
+import forms.validation.SectionError
 import models._
 import org.joda.time.LocalDateTime
 import org.joda.time.format.DateTimeFormat

--- a/src/main/scala/controllers/ApplicationData.scala
+++ b/src/main/scala/controllers/ApplicationData.scala
@@ -19,6 +19,7 @@ package controllers
 
 import forms._
 import forms.validation._
+import models.AppSectionNumber
 import play.api.libs.json._
 
 object ApplicationData {
@@ -34,12 +35,13 @@ object ApplicationData {
   implicit val civReads = Json.reads[CostItemValues]
   implicit val ciReads = Json.reads[CostItem]
 
-  def itemChecksFor(sectionNumber: Int): Map[String, FieldCheck] = sectionNumber match {
-    case 6 => Map("item" -> fromValidator(CostItemValidator))
+  def itemChecksFor(sectionNumber: AppSectionNumber): Map[String, FieldCheck] = sectionNumber.num.value match {
+    case
+      6 => Map("item" -> fromValidator(CostItemValidator))
     case _ => Map()
   }
 
-  def itemFieldsFor(sectionNum: Int): Option[Seq[Field]] = sectionNum match {
+  def itemFieldsFor(sectionNum: AppSectionNumber): Option[Seq[Field]] = sectionNum.num.value match {
     case 6 => Some(Seq(CostItemField("item")))
     case _ => None
   }

--- a/src/main/scala/controllers/ApplicationPreviewController.scala
+++ b/src/main/scala/controllers/ApplicationPreviewController.scala
@@ -18,7 +18,7 @@
 package controllers
 
 import javax.inject.Inject
-
+import eu.timepit.refined.auto._
 import actions.AppSectionAction
 import forms.Field
 import forms.validation.CostItem
@@ -40,7 +40,7 @@ class ApplicationPreviewController @Inject()(
 
   implicit val ciReads = Json.reads[CostItem]
 
-  def previewSection(id: ApplicationId, sectionNumber: Int) = AppSectionAction(id, sectionNumber) { request =>
+  def previewSection(id: ApplicationId, sectionNumber: AppSectionNumber) = AppSectionAction(id, sectionNumber) { request =>
     val (backLink, editLink) = request.appSection.section.map(_.isComplete) match {
       case Some(true) =>
         (controllers.routes.ApplicationController.show(request.appSection.id).url,
@@ -67,7 +67,7 @@ class ApplicationPreviewController @Inject()(
     Ok(views.html.listSectionPreview(app, items, answers, backLink, editLink))
   }
 
-  def getFieldMap(form: ApplicationForm): Map[Int, Seq[Field]] = {
+  def getFieldMap(form: ApplicationForm): Map[AppSectionNumber, Seq[Field]] = {
     Map(form.sections.map(sec => sec.sectionNumber -> sec.fields): _*)
   }
 

--- a/src/main/scala/controllers/ApplicationResults.scala
+++ b/src/main/scala/controllers/ApplicationResults.scala
@@ -17,17 +17,17 @@
 
 package controllers
 
-import models.ApplicationId
+import models.{ApplicationId, AppSectionNumber}
 import play.api.mvc.Results._
 
 trait ApplicationResults {
 
   def wip(backLink: String) = Redirect(controllers.routes.OpportunityController.wip(backLink))
 
-  def sectionFormCall(applicationId: ApplicationId, sectionNumber: Int) =
+  def sectionFormCall(applicationId: ApplicationId, sectionNumber: AppSectionNumber) =
     controllers.routes.ApplicationController.showSectionForm(applicationId, sectionNumber)
 
-  def redirectToSectionForm(applicationId: ApplicationId, sectionNumber: Int) = Redirect(sectionFormCall(applicationId, sectionNumber))
+  def redirectToSectionForm(applicationId: ApplicationId, sectionNumber: AppSectionNumber) = Redirect(sectionFormCall(applicationId, sectionNumber))
 
   def redirectToOverview(applicationId: ApplicationId) = Redirect(controllers.routes.ApplicationController.show(applicationId))
 

--- a/src/main/scala/controllers/OpportunityController.scala
+++ b/src/main/scala/controllers/OpportunityController.scala
@@ -19,8 +19,9 @@ package controllers
 
 import javax.inject.Inject
 
+import eu.timepit.refined.auto._
 import actions.{OppSectionAction, OpportunityAction}
-import models.OpportunityId
+import models.{AppSectionNumber, OppSectionNumber, OpportunityId}
 import play.api.mvc.{Action, Controller}
 import services.{ApplicationFormOps, OpportunityOps}
 
@@ -37,11 +38,11 @@ class OpportunityController @Inject()(
     opportunities.getOpenOpportunitySummaries.map { os => Ok(views.html.showOpportunities(os)) }
   }
 
-  def showOpportunity(id: OpportunityId, sectionNumber: Option[Int]) = OpportunityAction(id) { request =>
-    Redirect(controllers.routes.OpportunityController.showOpportunitySection(id, sectionNumber.getOrElse(1)))
+  def showOpportunity(id: OpportunityId, sectionNumber: Option[OppSectionNumber]) = OpportunityAction(id) { request =>
+    Redirect(controllers.routes.OpportunityController.showOpportunitySection(id, sectionNumber.getOrElse(OppSectionNumber(1))))
   }
 
-  def showOpportunitySection(id: OpportunityId, sectionNum: Int) = OppSectionAction(id, sectionNum).async { request =>
+  def showOpportunitySection(id: OpportunityId, sectionNum: OppSectionNumber) = OppSectionAction(id, sectionNum).async { request =>
     appForms.byOpportunityId(id).map {
       case Some(appForm) => Ok(views.html.showOpportunity(appForm, request.opportunity, request.section))
       case None => NotFound

--- a/src/main/scala/controllers/manage/DeadlineController.scala
+++ b/src/main/scala/controllers/manage/DeadlineController.scala
@@ -21,8 +21,9 @@ import javax.inject.Inject
 
 import actions.OpportunityAction
 import controllers.FieldCheckHelpers
+import eu.timepit.refined.auto._
+import forms.validation.{DateTimeRange, DateTimeRangeValues, FieldError}
 import forms.{DateTimeRangeField, DateValues}
-import forms.validation.{DateTimeRange, DateTimeRangeValues, FieldError, FieldHint}
 import models.{Opportunity, OpportunityId, Question}
 import org.joda.time.LocalDate
 import play.api.libs.json._

--- a/src/main/scala/controllers/manage/GrantValueController.scala
+++ b/src/main/scala/controllers/manage/GrantValueController.scala
@@ -21,6 +21,7 @@ import javax.inject.Inject
 
 import actions.OpportunityAction
 import controllers.FieldCheckHelpers
+import eu.timepit.refined.auto._
 import forms.CurrencyField
 import forms.validation.{CurrencyValidator, FieldError}
 import models._

--- a/src/main/scala/controllers/manage/OppSectionController.scala
+++ b/src/main/scala/controllers/manage/OppSectionController.scala
@@ -22,7 +22,7 @@ import javax.inject.Inject
 import actions.OpportunityAction
 import controllers.{FieldCheckHelpers, JsonForm, Preview}
 import forms.TextAreaField
-import models.{OppSectionType, Opportunity, OpportunityId, Question}
+import models.{AppSectionNumber, OppSectionNumber, OppSectionType, Opportunity, OpportunityId, Question}
 import play.api.libs.json._
 import play.api.mvc._
 import services.{ApplicationFormOps, OpportunityOps}
@@ -33,7 +33,7 @@ class OppSectionController @Inject()(appForms: ApplicationFormOps,opportunities:
   val sectionFieldName = "section"
   val sectionField = TextAreaField(None, sectionFieldName, 500)
 
-  def doEdit(opp: Opportunity, sectionNum: Int, initial: JsObject, errs: Seq[forms.validation.FieldError] = Nil) = {
+  def doEdit(opp: Opportunity, sectionNum: OppSectionNumber, initial: JsObject, errs: Seq[forms.validation.FieldError] = Nil) = {
     val hints = FieldCheckHelpers.hinting(initial, Map(sectionFieldName -> sectionField.check))
     opp.description.find(_.sectionNumber == sectionNum) match {
       case Some(section) =>
@@ -44,7 +44,7 @@ class OppSectionController @Inject()(appForms: ApplicationFormOps,opportunities:
     }
   }
 
-  def edit(id: OpportunityId, sectionNum: Int) = OpportunityAction(id).async { request =>
+  def edit(id: OpportunityId, sectionNum: OppSectionNumber) = OpportunityAction(id).async { request =>
     appForms.byOpportunityId(id).map {
       case Some(appForm) =>
         request.opportunity.description.find(_.sectionNumber == sectionNum) match {
@@ -58,7 +58,7 @@ class OppSectionController @Inject()(appForms: ApplicationFormOps,opportunities:
     }
   }
 
-  def save(id: OpportunityId, sectionNum: Int) = OpportunityAction(id).async(JsonForm.parser) { implicit request =>
+  def save(id: OpportunityId, sectionNum: OppSectionNumber) = OpportunityAction(id).async(JsonForm.parser) { implicit request =>
     (request.body.values \ sectionFieldName).toOption.map { fValue =>
       sectionField.check(sectionFieldName, fValue) match {
         case Nil =>
@@ -77,7 +77,7 @@ class OppSectionController @Inject()(appForms: ApplicationFormOps,opportunities:
     }.getOrElse(Future.successful(BadRequest))
   }
 
-  def view(id: OpportunityId, sectionNum: Int) = OpportunityAction(id).async { request =>
+  def view(id: OpportunityId, sectionNum: OppSectionNumber) = OpportunityAction(id).async { request =>
     appForms.byOpportunityId(id).map {
       case Some(appForm) => request.opportunity.publishedAt match {
         case Some(_) => Ok(views.html.manage.viewOppSection(request.opportunity, appForm, sectionNum, request.flash.get(PREVIEW_BACK_URL_FLASH)))
@@ -86,7 +86,7 @@ class OppSectionController @Inject()(appForms: ApplicationFormOps,opportunities:
       case None => NotFound
     }
   }
-  def preview(id: OpportunityId, sectionNum: Int) = OpportunityAction(id) { request =>
+  def preview(id: OpportunityId, sectionNum: OppSectionNumber) = OpportunityAction(id) { request =>
       Ok(views.html.manage.previewOppSection(request.opportunity, sectionNum, request.flash.get(PREVIEW_BACK_URL_FLASH)))
   }
 }

--- a/src/main/scala/controllers/manage/OppSectionController.scala
+++ b/src/main/scala/controllers/manage/OppSectionController.scala
@@ -37,7 +37,7 @@ class OppSectionController @Inject()(appForms: ApplicationFormOps,opportunities:
     val hints = FieldCheckHelpers.hinting(initial, Map(sectionFieldName -> sectionField.check))
     opp.description.find(_.sectionNumber == sectionNum) match {
       case Some(section) =>
-        val q = Question(section.description.getOrElse(""), None, section.helpText)
+        val q = Question(section.description, None, section.helpText)
         Ok(views.html.manage.editOppSectionForm(sectionField, opp, section,
           routes.OppSectionController.edit(opp.id, sectionNum).url, Map(sectionFieldName -> q), initial, errs, hints))
       case None => NotFound
@@ -49,7 +49,7 @@ class OppSectionController @Inject()(appForms: ApplicationFormOps,opportunities:
       case Some(appForm) =>
         request.opportunity.description.find(_.sectionNumber == sectionNum) match {
           case Some(sect) if sect.sectionType == OppSectionType.Text =>
-            val answers = JsObject(Seq(sectionFieldName -> Json.toJson(sect.text)))
+            val answers = JsObject(Seq(sectionFieldName -> Json.toJson(sect.text.map(_.value))))
             doEdit(request.opportunity, sectionNum, answers)
           case Some(sect) => Ok(views.html.manage.whatWeWillAskPreview(request.uri, request.opportunity, sectionNum, appForm))
           case None => NotFound
@@ -86,7 +86,7 @@ class OppSectionController @Inject()(appForms: ApplicationFormOps,opportunities:
       case None => NotFound
     }
   }
-  def preview(id: OpportunityId, sectionid: Int) = OpportunityAction(id) { request =>
-      Ok(views.html.manage.previewOppSection(request.opportunity, sectionid, request.flash.get(PREVIEW_BACK_URL_FLASH)))
+  def preview(id: OpportunityId, sectionNum: Int) = OpportunityAction(id) { request =>
+      Ok(views.html.manage.previewOppSection(request.opportunity, sectionNum, request.flash.get(PREVIEW_BACK_URL_FLASH)))
   }
 }

--- a/src/main/scala/controllers/manage/SummarySave.scala
+++ b/src/main/scala/controllers/manage/SummarySave.scala
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2016  Department for Business, Energy and Industrial Strategy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package controllers.manage
 
 import actions.OpportunityAction

--- a/src/main/scala/controllers/manage/TitleController.scala
+++ b/src/main/scala/controllers/manage/TitleController.scala
@@ -22,6 +22,7 @@ import javax.inject.Inject
 import actions.OpportunityAction
 import controllers.FieldCheckHelpers
 import controllers.FieldCheckHelpers.hinting
+import eu.timepit.refined.auto._
 import forms.TextField
 import forms.validation.FieldError
 import models.{Opportunity, OpportunityId, Question}

--- a/src/main/scala/controllers/package.scala
+++ b/src/main/scala/controllers/package.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2016  Department for Business, Energy and Industrial Strategy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import eu.timepit.refined.api.{RefType, Validate}
+import play.api.libs.json.{JsError, JsSuccess, Reads, Writes}
+import play.api.mvc.{PathBindable, QueryStringBindable}
+
+package object controllers {
+  trait RefinedBinders {
+    implicit def writeRefined[T, P, F[_, _]](
+                                              implicit writesT: Writes[T],
+                                              reftype: RefType[F]
+                                            ): Writes[F[T, P]] = Writes(value => writesT.writes(reftype.unwrap(value)))
+
+    implicit def readRefined[T, P, F[_, _]](
+                                             implicit readsT: Reads[T],
+                                             reftype: RefType[F],
+                                             validate: Validate[T, P]
+                                           ): Reads[F[T, P]] =
+      Reads(jsValue =>
+        readsT.reads(jsValue).flatMap { valueT =>
+          reftype.refine[P](valueT) match {
+            case Right(valueP) => JsSuccess(valueP)
+            case Left(error) => JsError(error)
+          }
+        })
+
+    implicit def pathBindRefined[T, P, F[_, _]](
+                                                 implicit
+                                                 pathBindT: PathBindable[T],
+                                                 reftype: RefType[F],
+                                                 validate: Validate[T, P]
+                                               ): PathBindable[F[T, P]] =
+      new PathBindable[F[T, P]] {
+        override def unbind(key: String, value: F[T, P]): String =
+          pathBindT.unbind(key, reftype.unwrap(value))
+
+        override def bind(key: String, value: String): Either[String, F[T, P]] =
+          pathBindT.bind(key, value).right.flatMap(reftype.refine(_)(validate))
+      }
+
+    implicit def queryBindRefined[T, P, F[_, _]](
+                                                  implicit
+                                                  queryBindT: QueryStringBindable[T],
+                                                  reftype: RefType[F],
+                                                  validate: Validate[T, P]
+                                                ): QueryStringBindable[F[T, P]] = new QueryStringBindable[F[T, P]] {
+      override def unbind(key: String, value: F[T, P]) =
+        queryBindT.unbind(key, reftype.unwrap(value))
+
+      override def bind(key: String, params: Map[String, Seq[String]]) =
+        queryBindT.bind(key, params).map(_.right.flatMap(reftype.refine(_)(validate)))
+    }
+  }
+
+  object RefinedBinders extends RefinedBinders
+}

--- a/src/main/scala/controllers/package.scala
+++ b/src/main/scala/controllers/package.scala
@@ -18,6 +18,7 @@
 import eu.timepit.refined.api.{RefType, Validate}
 import play.api.libs.json.{JsError, JsSuccess, Reads, Writes}
 import play.api.mvc.{PathBindable, QueryStringBindable}
+import scala.language.higherKinds
 
 package object controllers {
   trait RefinedBinders {

--- a/src/main/scala/models/Application.scala
+++ b/src/main/scala/models/Application.scala
@@ -57,16 +57,17 @@ case class ApplicationDetail(
                               opportunity: OpportunitySummary,
                               applicationForm: ApplicationForm,
                               sections: Seq[ApplicationSection]) {
-  def sectionDetail(sectionNumber: AppSectionNumber): ApplicationSectionDetail =
-    ApplicationSectionDetail(
-      id,
-      sectionCount,
-      completedSectionCount,
-      opportunity,
-      // TODO: remove the naked get
-      applicationForm.sections.find(_.sectionNumber == sectionNumber).get,
-      sections.find(_.sectionNumber == sectionNumber)
-    )
+  def sectionDetail(sectionNumber: AppSectionNumber): Option[ApplicationSectionDetail] =
+    applicationForm.section(sectionNumber).map { formSection =>
+      ApplicationSectionDetail(
+        id,
+        sectionCount,
+        completedSectionCount,
+        opportunity,
+        formSection,
+        section(sectionNumber)
+      )
+    }
 
   def section(num: AppSectionNumber): Option[ApplicationSection] = sections.find(_.sectionNumber == num)
 }
@@ -80,6 +81,7 @@ case class ApplicationSectionDetail(
                                      section: Option[ApplicationSection]
                                    ) {
   val sectionNumber = formSection.sectionNumber
+  lazy val answers = section.map(_.answers).getOrElse(JsObject(Nil))
 }
 
 case class SubmittedApplicationRef(applicationRef: Long) extends AnyVal

--- a/src/main/scala/models/Application.scala
+++ b/src/main/scala/models/Application.scala
@@ -17,11 +17,13 @@
 
 package models
 
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.numeric.Positive
 import org.joda.time.LocalDateTime
 import org.joda.time.format.DateTimeFormat
 import play.api.libs.json.JsObject
 
-case class ApplicationId(id: Long) extends AnyVal
+case class ApplicationId(id: Long Refined Positive)
 
 case class ApplicationSectionId(id: Long) extends AnyVal
 

--- a/src/main/scala/models/Application.scala
+++ b/src/main/scala/models/Application.scala
@@ -17,15 +17,13 @@
 
 package models
 
-import eu.timepit.refined.api.Refined
-import eu.timepit.refined.numeric.Positive
 import org.joda.time.LocalDateTime
 import org.joda.time.format.DateTimeFormat
 import play.api.libs.json.JsObject
 
-case class ApplicationId(id: Long Refined Positive)
+case class ApplicationId(id: LongId)
 
-case class ApplicationSectionId(id: Long) extends AnyVal
+case class ApplicationSectionId(id: LongId)
 
 case class Application(id: ApplicationId, applicationFormId: ApplicationFormId, personalReference: Option[String])
 

--- a/src/main/scala/models/ApplicationForm.scala
+++ b/src/main/scala/models/ApplicationForm.scala
@@ -24,7 +24,7 @@ case class ApplicationFormId(id: LongId)
 
 case class ApplicationFormQuestion(key: String, text: NonEmptyString, description: Option[NonEmptyString], helpText: Option[NonEmptyString])
 
-case class ApplicationFormSection(sectionNumber: Int, title: String, questions: Seq[ApplicationFormQuestion], sectionType: ApplicationFormSectionType, fields: Seq[Field]) {
+case class ApplicationFormSection(sectionNumber: AppSectionNumber, title: String, questions: Seq[ApplicationFormQuestion], sectionType: ApplicationFormSectionType, fields: Seq[Field]) {
   /**
     * Convenience function to turn the sequence of `ApplicationFormQuestions` sent by the backend into a
     * Map of `String -> Question` used by the form templates
@@ -42,7 +42,9 @@ case class ApplicationFormSection(sectionNumber: Int, title: String, questions: 
   }
 }
 
-case class ApplicationForm(id: ApplicationFormId, opportunityId: OpportunityId, sections: Seq[ApplicationFormSection])
+case class ApplicationForm(id: ApplicationFormId, opportunityId: OpportunityId, sections: Seq[ApplicationFormSection]) {
+  def section(num: AppSectionNumber): Option[ApplicationFormSection] = sections.find(_.sectionNumber == num)
+}
 
 sealed trait ApplicationFormSectionType {
   def name: String

--- a/src/main/scala/models/ApplicationForm.scala
+++ b/src/main/scala/models/ApplicationForm.scala
@@ -20,9 +20,9 @@ package models
 import forms.Field
 import play.api.libs.json._
 
-case class ApplicationFormId(id: Long) extends AnyVal
+case class ApplicationFormId(id: LongId)
 
-case class ApplicationFormQuestion(key: String, text: String, description: Option[String], helpText: Option[String])
+case class ApplicationFormQuestion(key: String, text: NonEmptyString, description: Option[NonEmptyString], helpText: Option[NonEmptyString])
 
 case class ApplicationFormSection(sectionNumber: Int, title: String, questions: Seq[ApplicationFormQuestion], sectionType: ApplicationFormSectionType, fields: Seq[Field]) {
   /**

--- a/src/main/scala/models/Opportunity.scala
+++ b/src/main/scala/models/Opportunity.scala
@@ -19,9 +19,7 @@ package models
 
 import enumeratum.EnumEntry.Lowercase
 import enumeratum._
-import eu.timepit.refined.api.Refined
 import org.joda.time.{DateTime, LocalDate}
-import eu.timepit.refined.numeric.Positive
 
 sealed trait OppSectionType extends EnumEntry with Lowercase
 
@@ -37,7 +35,7 @@ case class OpportunityId(id: IdType)
 
 object OpportunityId {
   implicit val ordering = new Ordering[OpportunityId] {
-    override def compare(x: OpportunityId, y: OpportunityId) = implicitly[Ordering[Long]].compare(x.id.value, y.id.value)
+    override def compare(x: OpportunityId, y: OpportunityId) = implicitly[Ordering[IdType]].compare(x.id, y.id)
   }
 }
 

--- a/src/main/scala/models/Opportunity.scala
+++ b/src/main/scala/models/Opportunity.scala
@@ -19,7 +19,9 @@ package models
 
 import enumeratum.EnumEntry.Lowercase
 import enumeratum._
+import eu.timepit.refined.api.Refined
 import org.joda.time.{DateTime, LocalDate}
+import eu.timepit.refined.numeric.Positive
 
 sealed trait OppSectionType extends EnumEntry with Lowercase
 
@@ -29,11 +31,15 @@ object OppSectionType extends Enum[OppSectionType] with PlayJsonEnum[OppSectionT
   case object Questions extends OppSectionType
 
   case object Text extends OppSectionType
-
 }
 
+case class OpportunityId(id: IdType)
 
-case class OpportunityId(id: Long) extends AnyVal
+object OpportunityId {
+  implicit val ordering = new Ordering[OpportunityId] {
+    override def compare(x: OpportunityId, y: OpportunityId) = implicitly[Ordering[Long]].compare(x.id.value, y.id.value)
+  }
+}
 
 case class OpportunityDescriptionSection(sectionNumber: Int, title: String, text: Option[String], description: Option[String], helpText: Option[String], sectionType: OppSectionType)
 

--- a/src/main/scala/models/Opportunity.scala
+++ b/src/main/scala/models/Opportunity.scala
@@ -19,6 +19,9 @@ package models
 
 import enumeratum.EnumEntry.Lowercase
 import enumeratum._
+import eu.timepit.refined.auto._
+import eu.timepit.refined.numeric.Positive
+import eu.timepit.refined.refineV
 import org.joda.time.{DateTime, LocalDate}
 
 sealed trait OppSectionType extends EnumEntry with Lowercase
@@ -29,6 +32,7 @@ object OppSectionType extends Enum[OppSectionType] with PlayJsonEnum[OppSectionT
   case object Questions extends OppSectionType
 
   case object Text extends OppSectionType
+
 }
 
 case class OpportunityId(id: LongId)
@@ -39,7 +43,28 @@ object OpportunityId {
   }
 }
 
-case class OpportunityDescriptionSection(sectionNumber: Int, title: NonEmptyString, text: Option[NonEmptyString], description: NonEmptyString, helpText: Option[NonEmptyString], sectionType: OppSectionType)
+case class SectionId(id: LongId)
+
+case class OppSectionNumber(num: PosInt) {
+  def next: Option[OppSectionNumber] = refineV[Positive](num + 1).fold(
+    _ => None,
+    v => Some(OppSectionNumber(v))
+  )
+
+  def prev: Option[OppSectionNumber] = refineV[Positive](num - 1).fold(
+    _ => None,
+    v => Some(OppSectionNumber(v))
+  )
+}
+
+object OppSectionNumber {
+  implicit val ord = new Ordering[OppSectionNumber] {
+    override def compare(x: OppSectionNumber, y: OppSectionNumber): Int =
+      implicitly[Ordering[PosInt]].compare(x.num, y.num)
+  }
+}
+
+case class OpportunityDescriptionSection(sectionNumber: OppSectionNumber, title: NonEmptyString, text: Option[NonEmptyString], description: NonEmptyString, helpText: Option[NonEmptyString], sectionType: OppSectionType)
 
 case class OpportunityValue(amount: BigDecimal, unit: String)
 

--- a/src/main/scala/models/Opportunity.scala
+++ b/src/main/scala/models/Opportunity.scala
@@ -31,15 +31,15 @@ object OppSectionType extends Enum[OppSectionType] with PlayJsonEnum[OppSectionT
   case object Text extends OppSectionType
 }
 
-case class OpportunityId(id: IdType)
+case class OpportunityId(id: LongId)
 
 object OpportunityId {
   implicit val ordering = new Ordering[OpportunityId] {
-    override def compare(x: OpportunityId, y: OpportunityId) = implicitly[Ordering[IdType]].compare(x.id, y.id)
+    override def compare(x: OpportunityId, y: OpportunityId) = implicitly[Ordering[LongId]].compare(x.id, y.id)
   }
 }
 
-case class OpportunityDescriptionSection(sectionNumber: Int, title: String, text: Option[String], description: Option[String], helpText: Option[String], sectionType: OppSectionType)
+case class OpportunityDescriptionSection(sectionNumber: Int, title: NonEmptyString, text: Option[NonEmptyString], description: NonEmptyString, helpText: Option[NonEmptyString], sectionType: OppSectionType)
 
 case class OpportunityValue(amount: BigDecimal, unit: String)
 

--- a/src/main/scala/models/Question.scala
+++ b/src/main/scala/models/Question.scala
@@ -17,4 +17,4 @@
 
 package models
 
-case class Question(text: String, longDescription: Option[String] = None, helpText: Option[String] = None)
+case class Question(text: NonEmptyString, longDescription: Option[NonEmptyString] = None, helpText: Option[NonEmptyString] = None)

--- a/src/main/scala/models/package.scala
+++ b/src/main/scala/models/package.scala
@@ -16,12 +16,15 @@
  */
 
 import eu.timepit.refined.api.Refined
+import eu.timepit.refined.collection.NonEmpty
 import eu.timepit.refined.numeric.Positive
 
 package object models {
-  type IdType = Long Refined Positive
+  type LongId = Long Refined Positive
 
-  implicit val idTypeOrdering = new Ordering[IdType] {
-    override def compare(x: IdType, y: IdType) = implicitly[Ordering[Long]].compare(x.value, y.value)
+  type NonEmptyString = String Refined NonEmpty
+
+  implicit val idTypeOrdering = new Ordering[LongId] {
+    override def compare(x: LongId, y: LongId) = implicitly[Ordering[Long]].compare(x.value, y.value)
   }
 }

--- a/src/main/scala/models/package.scala
+++ b/src/main/scala/models/package.scala
@@ -1,6 +1,27 @@
+/*
+ * Copyright (C) 2016  Department for Business, Energy and Industrial Strategy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.numeric.Positive
 
 package object models {
   type IdType = Long Refined Positive
+
+  implicit val idTypeOrdering = new Ordering[IdType] {
+    override def compare(x: IdType, y: IdType) = implicitly[Ordering[Long]].compare(x.value, y.value)
+  }
 }

--- a/src/main/scala/models/package.scala
+++ b/src/main/scala/models/package.scala
@@ -1,0 +1,6 @@
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.numeric.Positive
+
+package object models {
+  type IdType = Long Refined Positive
+}

--- a/src/main/scala/models/package.scala
+++ b/src/main/scala/models/package.scala
@@ -17,14 +17,20 @@
 
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.collection.NonEmpty
-import eu.timepit.refined.numeric.Positive
+import eu.timepit.refined.numeric.{NonNegative, Positive}
 
 package object models {
   type LongId = Long Refined Positive
 
   type NonEmptyString = String Refined NonEmpty
+  type NonNegativeInt = Int Refined NonNegative
+  type PosInt = Int Refined Positive
 
-  implicit val idTypeOrdering = new Ordering[LongId] {
-    override def compare(x: LongId, y: LongId) = implicitly[Ordering[Long]].compare(x.value, y.value)
+  implicit val longIdOrd = new Ordering[LongId] {
+    override def compare(x: LongId, y: LongId): Int = implicitly[Ordering[Long]].compare(x.value, y.value)
+  }
+
+  implicit val posIntOrd = new Ordering[PosInt] {
+    override def compare(x: PosInt, y: PosInt): Int = implicitly[Ordering[Int]].compare(x.value, y.value)
   }
 }

--- a/src/main/scala/services/ApplicationFormService.scala
+++ b/src/main/scala/services/ApplicationFormService.scala
@@ -21,6 +21,7 @@ import javax.inject.Inject
 
 import com.wellfactored.playbindings.ValueClassFormats
 import config.Config
+import controllers.RefinedBinders
 import models._
 import play.api.libs.json._
 import play.api.libs.ws.WSClient
@@ -28,8 +29,7 @@ import play.api.libs.ws.WSClient
 import scala.concurrent.{ExecutionContext, Future}
 
 class ApplicationFormService @Inject()(val ws: WSClient)(implicit val ec: ExecutionContext)
-  extends ApplicationFormOps with JodaFormats with RestService with ValueClassFormats {
-
+  extends ApplicationFormOps with JodaFormats with RestService with ValueClassFormats with RefinedBinders {
   implicit val fieldReads = fields.FieldReads.fieldReads
   implicit val appFormQuestionReads = Json.reads[ApplicationFormQuestion]
   implicit val appSecRead = Json.reads[ApplicationFormSection]

--- a/src/main/scala/services/ApplicationFormService.scala
+++ b/src/main/scala/services/ApplicationFormService.scala
@@ -19,31 +19,32 @@ package services
 
 import javax.inject.Inject
 
-import com.wellfactored.playbindings.ValueClassFormats
 import config.Config
-import controllers.RefinedBinders
 import models._
-import play.api.libs.json._
 import play.api.libs.ws.WSClient
+
+class ApplicationFormURLs(baseUrl: String) {
+  def applicationForm(id: ApplicationFormId) =
+    s"$baseUrl/application_form/${id.id}"
+
+  def application(applicationFormId: ApplicationFormId) =
+    s"$baseUrl/application_form/${applicationFormId.id}/application"
+}
 
 import scala.concurrent.{ExecutionContext, Future}
 
 class ApplicationFormService @Inject()(val ws: WSClient)(implicit val ec: ExecutionContext)
-  extends ApplicationFormOps with JodaFormats with RestService with ValueClassFormats with RefinedBinders {
-  implicit val fieldReads = fields.FieldReads.fieldReads
-  implicit val appFormQuestionReads = Json.reads[ApplicationFormQuestion]
-  implicit val appSecRead = Json.reads[ApplicationFormSection]
-  implicit val appRead = Json.reads[ApplicationForm]
+  extends ApplicationFormOps with RestService {
 
   val baseUrl = Config.config.business.baseUrl
+  val urls = new ApplicationFormURLs(baseUrl)
+  val oppUrls = new OpportunityURLs(baseUrl)
 
   override def byId(id: ApplicationFormId): Future[Option[ApplicationForm]] = {
-    val url = s"$baseUrl/application_form/${id.id}"
-    getOpt[ApplicationForm](url)
+    getOpt[ApplicationForm](urls.applicationForm(id))
   }
 
   override def byOpportunityId(id: OpportunityId): Future[Option[ApplicationForm]] = {
-    val url = s"$baseUrl/opportunity/${id.id}/application_form"
-    getOpt[ApplicationForm](url)
+    getOpt[ApplicationForm](oppUrls.applicationForm(id))
   }
 }

--- a/src/main/scala/services/ApplicationOps.scala
+++ b/src/main/scala/services/ApplicationOps.scala
@@ -35,27 +35,27 @@ trait ApplicationOps {
 
   def detail(id: ApplicationId): Future[Option[ApplicationDetail]]
 
-  def sectionDetail(id: ApplicationId, sectionNum:Int): Future[Option[ApplicationSectionDetail]]
+  def sectionDetail(id: ApplicationId, sectionNum: AppSectionNumber): Future[Option[ApplicationSectionDetail]]
 
   def reset(): Future[Unit]
 
-  def saveSection(id: ApplicationId, sectionNumber: Int, doc: JsObject): Future[Unit]
+  def saveSection(id: ApplicationId, sectionNumber: AppSectionNumber, doc: JsObject): Future[Unit]
 
-  def completeSection(id: ApplicationId, sectionNumber: Int, doc: JsObject): Future[FieldErrors]
+  def completeSection(id: ApplicationId, sectionNumber: AppSectionNumber, doc: JsObject): Future[FieldErrors]
 
-  def saveItem(id: ApplicationId, sectionNumber: Int, doc: JsObject): Future[FieldErrors]
+  def saveItem(id: ApplicationId, sectionNumber: AppSectionNumber, doc: JsObject): Future[FieldErrors]
 
-  def getItem[T: Reads](id: ApplicationId, sectionNumber: Int, itemNumber: Int): Future[Option[T]]
+  def getItem[T: Reads](id: ApplicationId, sectionNumber: AppSectionNumber, itemNumber: Int): Future[Option[T]]
 
-  def deleteItem(id: ApplicationId, sectionNumber: Int, itemNumber: Int): Future[Unit]
+  def deleteItem(id: ApplicationId, sectionNumber: AppSectionNumber, itemNumber: Int): Future[Unit]
 
-  def getSection(id: ApplicationId, sectionNumber: Int): Future[Option[ApplicationSection]]
+  def getSection(id: ApplicationId, sectionNumber: AppSectionNumber): Future[Option[ApplicationSection]]
 
   def getSections(id: ApplicationId): Future[Seq[ApplicationSection]]
 
-  def deleteSection(id: ApplicationId, sectionNumber: Int): Future[Unit]
+  def deleteSection(id: ApplicationId, sectionNumber: AppSectionNumber): Future[Unit]
 
-  def clearSectionCompletedDate(id: ApplicationId, sectionNumber: Int): Future[Unit]
+  def clearSectionCompletedDate(id: ApplicationId, sectionNumber: AppSectionNumber): Future[Unit]
 
   def submit(id: ApplicationId): Future[Option[SubmittedApplicationRef]]
 

--- a/src/main/scala/services/ApplicationService.scala
+++ b/src/main/scala/services/ApplicationService.scala
@@ -21,7 +21,7 @@ import com.google.inject.Inject
 import com.wellfactored.playbindings.ValueClassFormats
 import config.Config
 import controllers.FieldCheckHelpers.FieldErrors
-import controllers.{FieldCheck, FieldCheckHelpers, FieldChecks}
+import controllers.{FieldCheck, FieldCheckHelpers, FieldChecks, RefinedBinders}
 import forms.validation.{CostItem, CostItemValues, CostSectionValidator, FieldError}
 import models._
 import play.api.libs.json._
@@ -30,7 +30,7 @@ import play.api.libs.ws.WSClient
 import scala.concurrent.{ExecutionContext, Future}
 
 class ApplicationService @Inject()(val ws: WSClient)(implicit val ec: ExecutionContext)
-  extends ApplicationOps with JodaFormats with RestService with ValueClassFormats {
+  extends ApplicationOps with JodaFormats with RestService with ValueClassFormats with RefinedBinders {
   private val dtPattern = "dd MMM yyyy HH:mm:ss"
   implicit val dtReads = Reads.jodaDateReads(dtPattern)
   implicit val dtWrites = Writes.jodaDateWrites(dtPattern)
@@ -143,7 +143,7 @@ class ApplicationService @Inject()(val ws: WSClient)(implicit val ec: ExecutionC
 
   override def reset(): Future[Unit] = {
     val url = s"$baseUrl/reset"
-    post(url, None)
+    post(url, "")
   }
 
   override def deleteSection(id: ApplicationId, sectionNumber: Int): Future[Unit] = {
@@ -153,7 +153,7 @@ class ApplicationService @Inject()(val ws: WSClient)(implicit val ec: ExecutionC
 
   override def clearSectionCompletedDate(id: ApplicationId, sectionNumber: Int): Future[Unit] = {
     val url = s"$baseUrl/application/${id.id}/section/$sectionNumber/markNotCompleted"
-    put(url, None)
+    put(url, "")
   }
 
   override def submit(id: ApplicationId): Future[Option[SubmittedApplicationRef]] = {

--- a/src/main/scala/services/ApplicationService.scala
+++ b/src/main/scala/services/ApplicationService.scala
@@ -18,60 +18,71 @@
 package services
 
 import com.google.inject.Inject
-import com.wellfactored.playbindings.ValueClassFormats
 import config.Config
 import controllers.FieldCheckHelpers.FieldErrors
-import controllers.{FieldCheck, FieldCheckHelpers, FieldChecks, RefinedBinders}
-import forms.validation.{CostItem, CostItemValues, CostSectionValidator, FieldError}
+import controllers.{FieldCheck, FieldCheckHelpers, FieldChecks}
+import forms.validation.{CostSectionValidator, FieldError}
 import models._
 import play.api.libs.json._
 import play.api.libs.ws.WSClient
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class ApplicationService @Inject()(val ws: WSClient)(implicit val ec: ExecutionContext)
-  extends ApplicationOps with JodaFormats with RestService with ValueClassFormats with RefinedBinders {
-  private val dtPattern = "dd MMM yyyy HH:mm:ss"
-  implicit val dtReads = Reads.jodaDateReads(dtPattern)
-  implicit val dtWrites = Writes.jodaDateWrites(dtPattern)
+class ApplicationURLs(baseUrl: String) {
+  def application(id: ApplicationId): String =
+    s"$baseUrl/application/${id.id}"
 
-  implicit val jldReads = Reads.jodaLocalDateReads("d MMM yyyy")
-  implicit val fieldReads = fields.FieldReads.fieldReads
-  implicit val appSectionReads = Json.reads[ApplicationSection]
-  implicit val appReads = Json.reads[Application]
-  implicit val appSecOvRead = Json.reads[ApplicationSectionOverview]
-  implicit val appOvRead = Json.reads[ApplicationOverview]
-  implicit val saRefReads = Json.reads[SubmittedApplicationRef]
-  implicit val oppSecReads = Json.reads[OpportunityDescriptionSection]
-  implicit val oppValueReads = Json.reads[OpportunityValue]
-  implicit val oppDurReads = Json.reads[OpportunityDuration]
-  implicit val oppSummaryReads = Json.reads[OpportunitySummary]
-  implicit val oppReads = Json.reads[Opportunity]
-  implicit val appFormQReads = Json.reads[ApplicationFormQuestion]
-  implicit val appFormSecReads = Json.reads[ApplicationFormSection]
-  implicit val appFormReads = Json.reads[ApplicationForm]
-  implicit val appDetailReads = Json.reads[ApplicationDetail]
-  implicit val appSecDetailReads = Json.reads[ApplicationSectionDetail]
+  def detail(id: ApplicationId): String =
+    s"$baseUrl/application/${id.id}/detail"
+
+  def submit(id: ApplicationId) =
+    s"$baseUrl/application/${id.id}/submit"
+
+  def personalRef(id: ApplicationId) =
+    s"$baseUrl/application/${id.id}/personal-ref"
+
+  def markNotCompleted(id: ApplicationId, sectionNumber: AppSectionNumber) =
+    s"$baseUrl/application/${id.id}/section/${sectionNumber.num}/markNotCompleted"
+
+  def section(id: ApplicationId, sectionNumber: AppSectionNumber) =
+    s"$baseUrl/application/${id.id}/section/${sectionNumber.num}"
+
+  def sectionDetail(id: ApplicationId, sectionNumber: AppSectionNumber) =
+    s"$baseUrl/application/${id.id}/section/${sectionNumber.num}/detail"
+
+  def sections(id: ApplicationId) =
+    s"$baseUrl/application/${id.id}/sections"
+
+  def complete(id: ApplicationId, sectionNumber: AppSectionNumber) =
+    s"$baseUrl/application/${id.id}/section/${sectionNumber.num}/complete"
+
+  def item(id: ApplicationId, sectionNumber: AppSectionNumber, itemNumber: Int) =
+    s"$baseUrl/application/${id.id}/section/${sectionNumber.num}/item/$itemNumber"
+
+  def items(id: ApplicationId, sectionNumber: AppSectionNumber) =
+    s"$baseUrl/application/${id.id}/section/${sectionNumber.num}/items"
+
+  val reset = s"$baseUrl/reset"
+}
+
+class ApplicationService @Inject()(val ws: WSClient)(implicit val ec: ExecutionContext)
+  extends ApplicationOps with RestService {
 
   val baseUrl = Config.config.business.baseUrl
+  val urls = new ApplicationURLs(baseUrl)
+  val appFormUrls = new ApplicationFormURLs(baseUrl)
 
-  override def byId(id: ApplicationId): Future[Option[Application]] = {
-    val url = s"$baseUrl/application/${id.id}"
-    getOpt[Application](url)
-  }
+  override def byId(id: ApplicationId): Future[Option[Application]] =
+    getOpt[Application](urls.application(id))
 
-  override def saveSection(id: ApplicationId, sectionNumber: AppSectionNumber, doc: JsObject): Future[Unit] = {
-    val url = s"$baseUrl/application/${id.id}/section/$sectionNumber"
-    post(url, doc)
-  }
+  override def saveSection(id: ApplicationId, sectionNumber: AppSectionNumber, doc: JsObject): Future[Unit] =
+    post(urls.section(id, sectionNumber), doc)
 
   override def completeSection(id: ApplicationId, sectionNumber: AppSectionNumber, doc: JsObject): Future[FieldErrors] = {
     sectionDetail(id, sectionNumber).flatMap {
       case Some(app) =>
         FieldCheckHelpers.check(doc, checksFor(app.formSection)) match {
-          case Nil =>
-            val url = s"$baseUrl/application/${id.id}/section/$sectionNumber/complete"
-            post(url, doc).map(_ => List())
+          case Nil => post(urls.complete(id, sectionNumber), doc).map(_ => List())
           case errs => Future.successful(errs)
         }
       // TODO: Need better error handling here
@@ -79,90 +90,58 @@ class ApplicationService @Inject()(val ws: WSClient)(implicit val ec: ExecutionC
     }
   }
 
-  implicit val civReads = Json.reads[CostItemValues]
-  implicit val ciReads = Json.reads[CostItem]
-
   def checksFor(formSection: ApplicationFormSection): Map[String, FieldCheck] =
     formSection.sectionType match {
       case SectionTypeForm => formSection.fields.map(f => f.name -> f.check).toMap
       case SectionTypeList => Map("items" -> FieldChecks.fromValidator(CostSectionValidator(2000)))
     }
 
-
   override def saveItem(id: ApplicationId, sectionNumber: AppSectionNumber, doc: JsObject): Future[FieldErrors] = {
     val item = (doc \ "item").toOption.flatMap(_.validate[JsObject].asOpt).getOrElse(JsObject(Seq()))
     item \ "itemNumber" match {
       case JsDefined(JsNumber(itemNumber)) =>
-        val url = s"$baseUrl/application/${id.id}/section/$sectionNumber/item/$itemNumber"
-        put(url, item).map(_ => List())
+        put(urls.item(id, sectionNumber, itemNumber.toInt), item).map(_ => List())
       case _ =>
-        val url = s"$baseUrl/application/${id.id}/section/$sectionNumber/items"
-        post(url, item).map(_ => List())
+        post(urls.items(id, sectionNumber), item).map(_ => List())
     }
   }
 
-  override def deleteItem(id: ApplicationId, sectionNumber: AppSectionNumber, itemNumber: Int): Future[Unit] = {
-    val url = s"$baseUrl/application/${id.id}/section/$sectionNumber/item/$itemNumber"
-    delete(url)
-  }
+  override def deleteItem(id: ApplicationId, sectionNumber: AppSectionNumber, itemNumber: Int): Future[Unit] =
+    delete(urls.item(id, sectionNumber, itemNumber))
 
-  override def getItem[T: Reads](id: ApplicationId, sectionNumber: AppSectionNumber, itemNumber: Int): Future[Option[T]] = {
-    val url = s"$baseUrl/application/${id.id}/section/$sectionNumber/item/$itemNumber"
-    getOpt[T](url)
-  }
+  override def getItem[T: Reads](id: ApplicationId, sectionNumber: AppSectionNumber, itemNumber: Int): Future[Option[T]] =
+    getOpt[T](urls.item(id, sectionNumber, itemNumber))
 
-  override def getSection(id: ApplicationId, sectionNumber: AppSectionNumber): Future[Option[ApplicationSection]] = {
-    val url = s"$baseUrl/application/${id.id}/section/$sectionNumber"
-    getOpt[ApplicationSection](url)
-  }
+  override def getSection(id: ApplicationId, sectionNumber: AppSectionNumber): Future[Option[ApplicationSection]] =
+    getOpt[ApplicationSection](urls.section(id, sectionNumber))
 
-  override def getSections(id: ApplicationId): Future[Seq[ApplicationSection]] = {
-    val url = s"$baseUrl/application/${id.id}/sections"
-    getMany[ApplicationSection](url)
-  }
+  override def getSections(id: ApplicationId): Future[Seq[ApplicationSection]] =
+    getMany[ApplicationSection](urls.sections(id))
 
-  override def getOrCreateForForm(applicationFormId: ApplicationFormId): Future[Option[Application]] = {
-    val url = s"$baseUrl/application_form/${applicationFormId.id}/application"
-    getOpt[Application](url)
-  }
+  override def getOrCreateForForm(applicationFormId: ApplicationFormId): Future[Option[Application]] =
+    getOpt[Application](appFormUrls.application(applicationFormId))
 
-  override def overview(id: ApplicationId): Future[Option[ApplicationOverview]] = {
-    val url = s"$baseUrl/application/${id.id}"
-    getOpt[ApplicationOverview](url)
-  }
+  override def overview(id: ApplicationId): Future[Option[ApplicationOverview]] =
+    getOpt[ApplicationOverview](urls.application(id))
 
-  override def detail(id: ApplicationId): Future[Option[ApplicationDetail]] = {
-    val url = s"$baseUrl/application/${id.id}/detail"
-    getOpt[ApplicationDetail](url)
-  }
+  override def detail(id: ApplicationId): Future[Option[ApplicationDetail]] =
+    getOpt[ApplicationDetail](urls.detail(id))
 
-  override def sectionDetail(id: ApplicationId, sectionNum: AppSectionNumber): Future[Option[ApplicationSectionDetail]] = {
-    val url = s"$baseUrl/application/${id.id}/section/$sectionNum/detail"
-    getOpt[ApplicationSectionDetail](url)
-  }
+  override def sectionDetail(id: ApplicationId, sectionNumber: AppSectionNumber): Future[Option[ApplicationSectionDetail]] =
+    getOpt[ApplicationSectionDetail](urls.sectionDetail(id, sectionNumber))
 
-  override def reset(): Future[Unit] = {
-    val url = s"$baseUrl/reset"
-    post(url, "")
-  }
+  override def reset(): Future[Unit] =
+    post(urls.reset, "")
 
-  override def deleteSection(id: ApplicationId, sectionNumber: AppSectionNumber): Future[Unit] = {
-    val url = s"$baseUrl/application/${id.id}/section/$sectionNumber"
-    delete(url)
-  }
+  override def deleteSection(id: ApplicationId, sectionNumber: AppSectionNumber): Future[Unit] =
+    delete(urls.section(id, sectionNumber))
 
-  override def clearSectionCompletedDate(id: ApplicationId, sectionNumber: AppSectionNumber): Future[Unit] = {
-    val url = s"$baseUrl/application/${id.id}/section/$sectionNumber/markNotCompleted"
-    put(url, "")
-  }
+  override def clearSectionCompletedDate(id: ApplicationId, sectionNumber: AppSectionNumber): Future[Unit] =
+    put(urls.markNotCompleted(id, sectionNumber), "")
 
-  override def submit(id: ApplicationId): Future[Option[SubmittedApplicationRef]] = {
-    val url = s"$baseUrl/application/${id.id}/submit"
-    postWithResult[SubmittedApplicationRef, String](url, "")
-  }
+  override def submit(id: ApplicationId): Future[Option[SubmittedApplicationRef]] =
+    postWithResult[SubmittedApplicationRef, String](urls.submit(id), "")
 
-  override def updatePersonalReference(id: ApplicationId, reference: String) = {
-    val url = s"$baseUrl/application/${id.id}/personal-ref"
-    post(url, reference)
-  }
+  override def updatePersonalReference(id: ApplicationId, reference: String) =
+    post(urls.personalRef(id), reference)
 }

--- a/src/main/scala/services/ApplicationService.scala
+++ b/src/main/scala/services/ApplicationService.scala
@@ -60,12 +60,12 @@ class ApplicationService @Inject()(val ws: WSClient)(implicit val ec: ExecutionC
     getOpt[Application](url)
   }
 
-  override def saveSection(id: ApplicationId, sectionNumber: Int, doc: JsObject): Future[Unit] = {
+  override def saveSection(id: ApplicationId, sectionNumber: AppSectionNumber, doc: JsObject): Future[Unit] = {
     val url = s"$baseUrl/application/${id.id}/section/$sectionNumber"
     post(url, doc)
   }
 
-  override def completeSection(id: ApplicationId, sectionNumber: Int, doc: JsObject): Future[FieldErrors] = {
+  override def completeSection(id: ApplicationId, sectionNumber: AppSectionNumber, doc: JsObject): Future[FieldErrors] = {
     sectionDetail(id, sectionNumber).flatMap {
       case Some(app) =>
         FieldCheckHelpers.check(doc, checksFor(app.formSection)) match {
@@ -89,7 +89,7 @@ class ApplicationService @Inject()(val ws: WSClient)(implicit val ec: ExecutionC
     }
 
 
-  override def saveItem(id: ApplicationId, sectionNumber: Int, doc: JsObject): Future[FieldErrors] = {
+  override def saveItem(id: ApplicationId, sectionNumber: AppSectionNumber, doc: JsObject): Future[FieldErrors] = {
     val item = (doc \ "item").toOption.flatMap(_.validate[JsObject].asOpt).getOrElse(JsObject(Seq()))
     item \ "itemNumber" match {
       case JsDefined(JsNumber(itemNumber)) =>
@@ -101,17 +101,17 @@ class ApplicationService @Inject()(val ws: WSClient)(implicit val ec: ExecutionC
     }
   }
 
-  override def deleteItem(id: ApplicationId, sectionNumber: Int, itemNumber: Int): Future[Unit] = {
+  override def deleteItem(id: ApplicationId, sectionNumber: AppSectionNumber, itemNumber: Int): Future[Unit] = {
     val url = s"$baseUrl/application/${id.id}/section/$sectionNumber/item/$itemNumber"
     delete(url)
   }
 
-  override def getItem[T: Reads](id: ApplicationId, sectionNumber: Int, itemNumber: Int): Future[Option[T]] = {
+  override def getItem[T: Reads](id: ApplicationId, sectionNumber: AppSectionNumber, itemNumber: Int): Future[Option[T]] = {
     val url = s"$baseUrl/application/${id.id}/section/$sectionNumber/item/$itemNumber"
     getOpt[T](url)
   }
 
-  override def getSection(id: ApplicationId, sectionNumber: Int): Future[Option[ApplicationSection]] = {
+  override def getSection(id: ApplicationId, sectionNumber: AppSectionNumber): Future[Option[ApplicationSection]] = {
     val url = s"$baseUrl/application/${id.id}/section/$sectionNumber"
     getOpt[ApplicationSection](url)
   }
@@ -136,7 +136,7 @@ class ApplicationService @Inject()(val ws: WSClient)(implicit val ec: ExecutionC
     getOpt[ApplicationDetail](url)
   }
 
-  override def sectionDetail(id: ApplicationId, sectionNum: Int): Future[Option[ApplicationSectionDetail]] = {
+  override def sectionDetail(id: ApplicationId, sectionNum: AppSectionNumber): Future[Option[ApplicationSectionDetail]] = {
     val url = s"$baseUrl/application/${id.id}/section/$sectionNum/detail"
     getOpt[ApplicationSectionDetail](url)
   }
@@ -146,12 +146,12 @@ class ApplicationService @Inject()(val ws: WSClient)(implicit val ec: ExecutionC
     post(url, "")
   }
 
-  override def deleteSection(id: ApplicationId, sectionNumber: Int): Future[Unit] = {
+  override def deleteSection(id: ApplicationId, sectionNumber: AppSectionNumber): Future[Unit] = {
     val url = s"$baseUrl/application/${id.id}/section/$sectionNumber"
     delete(url)
   }
 
-  override def clearSectionCompletedDate(id: ApplicationId, sectionNumber: Int): Future[Unit] = {
+  override def clearSectionCompletedDate(id: ApplicationId, sectionNumber: AppSectionNumber): Future[Unit] = {
     val url = s"$baseUrl/application/${id.id}/section/$sectionNumber/markNotCompleted"
     put(url, "")
   }

--- a/src/main/scala/services/JodaFormats.scala
+++ b/src/main/scala/services/JodaFormats.scala
@@ -25,17 +25,7 @@ import scala.util.{Failure, Success, Try}
 
 trait JodaFormats {
 
-  implicit val jodaLocalDateTimeFormat = new Format[LocalDateTime] {
-    val dtf = DateTimeFormat.forPattern("dd MMM yyyy HH:mm:ss")
 
-    override def writes(o: LocalDateTime): JsValue = JsString(dtf.print(o))
 
-    override def reads(json: JsValue): JsResult[LocalDateTime] =
-      implicitly[Reads[JsString]].reads(json).flatMap { js =>
-        Try(dtf.parseLocalDateTime(js.value)) match {
-          case Success(s) => JsSuccess(s)
-          case Failure(t) => JsError(t.getMessage)
-        }
-      }
-  }
+
 }

--- a/src/main/scala/services/OpportunityOps.scala
+++ b/src/main/scala/services/OpportunityOps.scala
@@ -33,7 +33,7 @@ trait OpportunityOps {
 
   def saveSummary(opp: OpportunitySummary): Future[Unit]
 
-  def saveDescriptionSectionText(id: OpportunityId, sectionNo: Int, descSect: Option[String]): Future[Unit]
+  def saveDescriptionSectionText(id: OpportunityId, sectionNum: OppSectionNumber, descSect: Option[String]): Future[Unit]
 
   def duplicate(id: OpportunityId): Future[Option[OpportunityId]]
 

--- a/src/main/scala/services/OpportunityService.scala
+++ b/src/main/scala/services/OpportunityService.scala
@@ -21,6 +21,7 @@ import javax.inject.Inject
 
 import com.wellfactored.playbindings.ValueClassFormats
 import config.Config
+import controllers.RefinedBinders
 import models._
 import org.joda.time.DateTime
 import play.api.libs.json.{Json, Reads, Writes}
@@ -28,7 +29,12 @@ import play.api.libs.ws.WSClient
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class OpportunityService @Inject()(val ws: WSClient)(implicit val ec: ExecutionContext) extends OpportunityOps with RestService with ValueClassFormats {
+class OpportunityService @Inject()(val ws: WSClient)(implicit val ec: ExecutionContext)
+  extends OpportunityOps
+    with RestService
+    with ValueClassFormats
+    with RefinedBinders {
+
   private val dtPattern = "dd MMM yyyy HH:mm:ss"
   implicit val dtReads = Reads.jodaDateReads(dtPattern)
   implicit val dtWrites = Writes.jodaDateWrites(dtPattern)
@@ -68,12 +74,12 @@ class OpportunityService @Inject()(val ws: WSClient)(implicit val ec: ExecutionC
     post(url, descSect.getOrElse(""))
   }
 
-  override def duplicate(id: OpportunityId) :Future[Option[OpportunityId]] = {
+  override def duplicate(id: OpportunityId): Future[Option[OpportunityId]] = {
     val url = s"$baseUrl/opportunity/${id.id}/duplicate"
     postWithResult[OpportunityId, String](url, "")
   }
 
-  override def publish(id: OpportunityId) :Future[Option[DateTime]] = {
+  override def publish(id: OpportunityId): Future[Option[DateTime]] = {
     val url = s"$baseUrl/opportunity/${id.id}/publish"
     postWithResult[DateTime, Option[String]](url, None)
   }

--- a/src/main/scala/services/OpportunityService.scala
+++ b/src/main/scala/services/OpportunityService.scala
@@ -19,68 +19,52 @@ package services
 
 import javax.inject.Inject
 
-import com.wellfactored.playbindings.ValueClassFormats
 import config.Config
-import controllers.RefinedBinders
 import models._
 import org.joda.time.DateTime
-import play.api.libs.json.{Json, Reads, Writes}
 import play.api.libs.ws.WSClient
 
 import scala.concurrent.{ExecutionContext, Future}
 
+class OpportunityURLs(baseUrl: String) {
+  val opportunitySummaries: String = s"$baseUrl/opportunity/summaries"
+  val openOpportunitySummaries: String = s"$baseUrl/opportunity/open/summaries"
+
+  def opportunity(id: OpportunityId): String = s"$baseUrl/opportunity/${id.id}"
+
+  def summary(id: OpportunityId): String = s"$baseUrl/opportunity/${id.id}/summary"
+
+  def descriptionSectionText(id: OpportunityId, sectionNum: OppSectionNumber): String = s"$baseUrl/manage/opportunity/${id.id}/description/${sectionNum.num}"
+
+  def duplicate(id: OpportunityId): String = s"$baseUrl/opportunity/${id.id}/duplicate"
+
+  def publish(id: OpportunityId): String = s"$baseUrl/opportunity/${id.id}/publish"
+
+  def applicationForm(id:OpportunityId) = s"$baseUrl/opportunity/${id.id}/application_form"
+}
+
 class OpportunityService @Inject()(val ws: WSClient)(implicit val ec: ExecutionContext)
-  extends OpportunityOps
-    with RestService
-    with ValueClassFormats
-    with RefinedBinders {
-
-  private val dtPattern = "dd MMM yyyy HH:mm:ss"
-  implicit val dtReads = Reads.jodaDateReads(dtPattern)
-  implicit val dtWrites = Writes.jodaDateWrites(dtPattern)
-
-  implicit val jldReads = Reads.jodaLocalDateReads("d MMM yyyy")
-  implicit val jldWrites = Writes.jodaLocalDateWrites("d MMM yyyy")
-  implicit val odsFmt = Json.format[OpportunityDescriptionSection]
-  implicit val ovFmt = Json.format[OpportunityValue]
-  implicit val odFmt = Json.format[OpportunityDuration]
-  implicit val oppFmt = Json.format[Opportunity]
-  implicit val oppSummaryFmt = Json.format[OpportunitySummary]
+  extends OpportunityOps with RestService {
 
   val baseUrl = Config.config.business.baseUrl
+  val urls = new OpportunityURLs(baseUrl)
 
-  override def getOpportunitySummaries: Future[Seq[Opportunity]] = {
-    val url = s"$baseUrl/opportunity/summaries"
-    getMany[Opportunity](url)
-  }
+  override def getOpportunitySummaries: Future[Seq[Opportunity]] =
+    getMany[Opportunity](urls.opportunitySummaries)
 
-  override def getOpenOpportunitySummaries: Future[Seq[Opportunity]] = {
-    val url = s"$baseUrl/opportunity/open/summaries"
-    getMany[Opportunity](url)
-  }
+  override def getOpenOpportunitySummaries: Future[Seq[Opportunity]] =
+    getMany[Opportunity](urls.openOpportunitySummaries)
 
-  override def byId(id: OpportunityId): Future[Option[Opportunity]] = {
-    val url = s"$baseUrl/opportunity/${id.id}"
-    getOpt[Opportunity](url)
-  }
+  override def byId(id: OpportunityId): Future[Option[Opportunity]] =
+    getOpt[Opportunity](urls.opportunity(id))
 
-  override def saveSummary(opp: OpportunitySummary): Future[Unit] = {
-    val url = s"$baseUrl/opportunity/${opp.id.id}/summary"
-    put(url, opp)
-  }
+  override def saveSummary(opp: OpportunitySummary): Future[Unit] =
+    put(urls.summary(opp.id), opp)
 
-  override def saveDescriptionSectionText(id: OpportunityId, sectionNum: OppSectionNumber, descSect: Option[String]): Future[Unit] = {
-    val url = s"$baseUrl/manage/opportunity/${id.id}/description/$sectionNum"
-    post(url, descSect.getOrElse(""))
-  }
+  override def saveDescriptionSectionText(id: OpportunityId, sectionNum: OppSectionNumber, descSect: Option[String]): Future[Unit] =
+    post(urls.descriptionSectionText(id, sectionNum), descSect.getOrElse(""))
 
-  override def duplicate(id: OpportunityId): Future[Option[OpportunityId]] = {
-    val url = s"$baseUrl/opportunity/${id.id}/duplicate"
-    postWithResult[OpportunityId, String](url, "")
-  }
+  override def duplicate(id: OpportunityId): Future[Option[OpportunityId]] = postWithResult[OpportunityId, String](urls.duplicate(id), "")
 
-  override def publish(id: OpportunityId): Future[Option[DateTime]] = {
-    val url = s"$baseUrl/opportunity/${id.id}/publish"
-    postWithResult[DateTime, Option[String]](url, None)
-  }
+  override def publish(id: OpportunityId): Future[Option[DateTime]] = postWithResult[DateTime, Option[String]](urls.publish(id), None)
 }

--- a/src/main/scala/services/OpportunityService.scala
+++ b/src/main/scala/services/OpportunityService.scala
@@ -69,8 +69,8 @@ class OpportunityService @Inject()(val ws: WSClient)(implicit val ec: ExecutionC
     put(url, opp)
   }
 
-  override def saveDescriptionSectionText(id: OpportunityId, sectionNo: Int, descSect: Option[String]): Future[Unit] = {
-    val url = s"$baseUrl/manage/opportunity/${id.id}/description/$sectionNo"
+  override def saveDescriptionSectionText(id: OpportunityId, sectionNum: OppSectionNumber, descSect: Option[String]): Future[Unit] = {
+    val url = s"$baseUrl/manage/opportunity/${id.id}/description/$sectionNum"
     post(url, descSect.getOrElse(""))
   }
 

--- a/src/main/scala/services/package.scala
+++ b/src/main/scala/services/package.scala
@@ -17,8 +17,8 @@
 
 import com.wellfactored.playbindings.ValueClassFormats
 import controllers.RefinedBinders
-import forms.validation.{CostItem, CostItemValues}
-import models.{Application, ApplicationDetail, ApplicationForm, ApplicationFormQuestion, ApplicationFormSection, ApplicationOverview, ApplicationSection, ApplicationSectionDetail, ApplicationSectionOverview, Opportunity, OpportunityDescriptionSection, OpportunityDuration, OpportunitySummary, OpportunityValue, SubmittedApplicationRef}
+import forms.validation._
+import models._
 import org.joda.time.LocalDateTime
 import org.joda.time.format.DateTimeFormat
 import play.api.libs.json._

--- a/src/main/scala/services/package.scala
+++ b/src/main/scala/services/package.scala
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2016  Department for Business, Energy and Industrial Strategy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 import com.wellfactored.playbindings.ValueClassFormats
 import controllers.RefinedBinders
 import forms.validation.{CostItem, CostItemValues}

--- a/src/main/scala/services/package.scala
+++ b/src/main/scala/services/package.scala
@@ -1,0 +1,62 @@
+import com.wellfactored.playbindings.ValueClassFormats
+import controllers.RefinedBinders
+import forms.validation.{CostItem, CostItemValues}
+import models.{Application, ApplicationDetail, ApplicationForm, ApplicationFormQuestion, ApplicationFormSection, ApplicationOverview, ApplicationSection, ApplicationSectionDetail, ApplicationSectionOverview, Opportunity, OpportunityDescriptionSection, OpportunityDuration, OpportunitySummary, OpportunityValue, SubmittedApplicationRef}
+import org.joda.time.LocalDateTime
+import org.joda.time.format.DateTimeFormat
+import play.api.libs.json._
+
+import scala.util.{Failure, Success, Try}
+
+package object services
+  extends ValueClassFormats
+    with RefinedBinders {
+
+  implicit val jodaLocalDateTimeFormat = new Format[LocalDateTime] {
+    val dtf = DateTimeFormat.forPattern("dd MMM yyyy HH:mm:ss")
+
+    override def writes(o: LocalDateTime): JsValue = JsString(dtf.print(o))
+
+    override def reads(json: JsValue): JsResult[LocalDateTime] =
+      implicitly[Reads[JsString]].reads(json).flatMap { js =>
+        Try(dtf.parseLocalDateTime(js.value)) match {
+          case Success(s) => JsSuccess(s)
+          case Failure(t) => JsError(t.getMessage)
+        }
+      }
+  }
+
+  implicit val fieldReads = fields.FieldReads.fieldReads
+
+  private val dtPattern = "dd MMM yyyy HH:mm:ss"
+  implicit val dtReads = Reads.jodaDateReads(dtPattern)
+  implicit val dtWrites = Writes.jodaDateWrites(dtPattern)
+
+  implicit val jldReads = Reads.jodaLocalDateReads("d MMM yyyy")
+  implicit val jldWrites = Writes.jodaLocalDateWrites("d MMM yyyy")
+
+  implicit val odsFmt = Json.format[OpportunityDescriptionSection]
+  implicit val ovFmt = Json.format[OpportunityValue]
+  implicit val odFmt = Json.format[OpportunityDuration]
+  implicit val oppFmt = Json.format[Opportunity]
+  implicit val oppSummaryFmt = Json.format[OpportunitySummary]
+
+  implicit val appSectionReads = Json.reads[ApplicationSection]
+  implicit val appReads = Json.reads[Application]
+  implicit val appSecOvRead = Json.reads[ApplicationSectionOverview]
+  implicit val appOvRead = Json.reads[ApplicationOverview]
+  implicit val saRefReads = Json.reads[SubmittedApplicationRef]
+  implicit val oppSecReads = Json.reads[OpportunityDescriptionSection]
+  implicit val oppValueReads = Json.reads[OpportunityValue]
+  implicit val oppDurReads = Json.reads[OpportunityDuration]
+  implicit val oppSummaryReads = Json.reads[OpportunitySummary]
+  implicit val oppReads = Json.reads[Opportunity]
+  implicit val appFormQReads = Json.reads[ApplicationFormQuestion]
+  implicit val appFormSecReads = Json.reads[ApplicationFormSection]
+  implicit val appFormReads = Json.reads[ApplicationForm]
+  implicit val appDetailReads = Json.reads[ApplicationDetail]
+  implicit val appSecDetailReads = Json.reads[ApplicationSectionDetail]
+
+  implicit val civReads = Json.reads[CostItemValues]
+  implicit val ciReads = Json.reads[CostItem]
+}

--- a/src/main/scala/views/html/helpers/package.scala
+++ b/src/main/scala/views/html/helpers/package.scala
@@ -17,6 +17,8 @@
 
 package views.html
 
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.numeric.Positive
 import forms.{TextAreaField, TextField}
 import models.ApplicationForm
 import play.twirl.api.Html
@@ -40,5 +42,9 @@ package object helpers {
 
     views.html.partials.oppQuestionsSection(appForm, Map(constraints: _*), Map(descriptions: _*))
   }
+
+  def formatId(id: Long): String = f"RIFS $id%04d"
+
+  def formatId(id: Long Refined Positive): String = formatId(id.value)
 
 }

--- a/src/main/scala/views/html/helpers/package.scala
+++ b/src/main/scala/views/html/helpers/package.scala
@@ -18,9 +18,10 @@
 package views.html
 
 import eu.timepit.refined.api.Refined
+import eu.timepit.refined.auto._
 import eu.timepit.refined.numeric.Positive
 import forms.{TextAreaField, TextField}
-import models.ApplicationForm
+import models.{ApplicationForm, NonEmptyString}
 import play.twirl.api.Html
 
 package object helpers {
@@ -36,7 +37,7 @@ package object helpers {
     }
     val descriptions = appForm.sections.flatMap { s =>
       s.questions.flatMap { q =>
-        q.description.map(q.key -> _)
+        q.description.map(q.key -> _.value)
       }
     }
 
@@ -46,5 +47,9 @@ package object helpers {
   def formatId(id: Long): String = f"RIFS $id%04d"
 
   def formatId(id: Long Refined Positive): String = formatId(id.value)
+
+  def splitLines(s: String): Seq[String] = s.split("\n")
+
+  def splitLines(s: Option[NonEmptyString]): Seq[String] = s.map(nes=>splitLines(nes.value)).getOrElse(List[String]())
 
 }

--- a/src/main/twirl/views/applicationPreview.scala.html
+++ b/src/main/twirl/views/applicationPreview.scala.html
@@ -7,7 +7,7 @@
 
 @import models._
 @import partials._
-
+@import helpers._
 
 @sectionLink(title: String, sectionNum: Int) = {
     <span class="part-number">@sectionNum. </span>
@@ -20,10 +20,6 @@
     val (leftCols, b) = titles.splitAt(midpoint)
     val rightCols = b.map(Some(_)) :+ None
     leftCols.zip(rightCols)
-}
-
-@formatId(id: Long) = @{
-    f"RIFS $id%04d"
 }
 
 @main(s"Opportunity ${app.opportunity.title} - RIFS", backLink=Some(BackLink("Return to application overview",controllers.routes.ApplicationController.show(app.id).url)), displayUserName=Some("Experienced Eric")) {

--- a/src/main/twirl/views/applicationPreview.scala.html
+++ b/src/main/twirl/views/applicationPreview.scala.html
@@ -2,15 +2,15 @@
         app: ApplicationDetail,
         sections: Seq[ApplicationSection],
         title: Option[String],
-        answers: Map[Int, Seq[forms.Field]]
+        answers: Map[AppSectionNumber, Seq[forms.Field]]
 )
 
 @import models._
 @import partials._
 @import helpers._
 
-@sectionLink(title: String, sectionNum: Int) = {
-    <span class="part-number">@sectionNum. </span>
+@sectionLink(title: String, sectionNum: AppSectionNumber) = {
+    <span class="part-number">@sectionNum.num. </span>
     <a href="@controllers.routes.ApplicationController.showSectionForm(app.id, sectionNum)">@title</a>
 }
 

--- a/src/main/twirl/views/costItemForm.scala.html
+++ b/src/main/twirl/views/costItemForm.scala.html
@@ -8,7 +8,9 @@
         cancelLink: String,
         itemNumber: Option[Int]
 )
-    @import partials._
+
+@import partials._
+@import helpers._
 
 @createOrSave = @{
     itemNumber match {

--- a/src/main/twirl/views/costSectionList.scala.html
+++ b/src/main/twirl/views/costSectionList.scala.html
@@ -29,7 +29,7 @@
                 <p class="text">@q.longDescription</p>
                 <details>
                     <summary role="button"><span class="summary">Help with this section</span></summary>
-                    <div class="panel panel-border-narrow">@for(line <- q.helpText.getOrElse("").split("\n")) {
+                    <div class="panel panel-border-narrow">@for(line <- q.helpText.map(_.value).getOrElse("").split("\n")) {
                         <p>@line</p>
                     }</div>
                 </details>

--- a/src/main/twirl/views/costSectionList.scala.html
+++ b/src/main/twirl/views/costSectionList.scala.html
@@ -7,7 +7,8 @@
         errs: List[forms.validation.FieldError]
 )
 
-    @import partials._
+@import partials._
+@import helpers._
 
 @main(s"${formSection.title} - RIFS", backLink=Some(BackLink("Return to application overview",controllers.routes.ApplicationController.show(app.id).url)), displayUserName=Some("Experienced Eric")) {
     <div class="grid-row">

--- a/src/main/twirl/views/listSectionPreview.scala.html
+++ b/src/main/twirl/views/listSectionPreview.scala.html
@@ -6,7 +6,7 @@
         editButton: Option[String]
 )
 
-@import partials._
+@import helpers._
 
 @main(s"${app.formSection.title} - RIFS", backLink=Some(BackLink("Return to application overview",controllers.routes.ApplicationController.show(app.id).url)), displayUserName=Some("Experienced Eric")) {
     <div class="grid-row">

--- a/src/main/twirl/views/manage/editCostSectionForm.scala.html
+++ b/src/main/twirl/views/manage/editCostSectionForm.scala.html
@@ -11,7 +11,7 @@
     errs.filter(p => p.path == field.name)
 }
 
-@import views.html.partials._
+@import helpers._
 
 @main("Edit grant value - RIFS" , backLink=Some(BackLink("Opportunity template",controllers.manage.routes.OpportunityController.showOverviewPage(opp.id).url)), displayUserName = Some("Portfolio Peter")) {
 

--- a/src/main/twirl/views/manage/editDeadlinesForm.scala.html
+++ b/src/main/twirl/views/manage/editDeadlinesForm.scala.html
@@ -14,7 +14,7 @@
     <span class="error-message" role="alert">@e.err</span>
 }
 
-@import views.html.partials._
+@import helpers._
 
 @main("Edit Deadline - RIFS" , backLink=Some(BackLink("Opportunity template",controllers.manage.routes.OpportunityController.showOverviewPage(opp.id).url)), displayUserName = Some("Portfolio Peter")) {
 

--- a/src/main/twirl/views/manage/editOppSectionForm.scala.html
+++ b/src/main/twirl/views/manage/editOppSectionForm.scala.html
@@ -12,7 +12,7 @@
     errs.filter(p => p.path == field.name)
 }
 
-@import views.html.partials._
+@import views.html.helpers._
 
 @main("Edit description - RIFS" , backLink=Some(BackLink("Opportunity template",controllers.manage.routes.OpportunityController.showOverviewPage(opp.id).url)), displayUserName = Some("Portfolio Peter")) {
 

--- a/src/main/twirl/views/manage/editOppSectionForm.scala.html
+++ b/src/main/twirl/views/manage/editOppSectionForm.scala.html
@@ -12,7 +12,7 @@
     errs.filter(p => p.path == field.name)
 }
 
-@import views.html.helpers._
+@import helpers._
 
 @main("Edit description - RIFS" , backLink=Some(BackLink("Opportunity template",controllers.manage.routes.OpportunityController.showOverviewPage(opp.id).url)), displayUserName = Some("Portfolio Peter")) {
 

--- a/src/main/twirl/views/manage/editTitleForm.scala.html
+++ b/src/main/twirl/views/manage/editTitleForm.scala.html
@@ -11,7 +11,7 @@
     errs.filter(p => p.path == field.name)
 }
 
-@import views.html.partials._
+@import views.html.helpers._
 
 @main("Edit title - RIFS", backLink=Some(BackLink("Opportunity template",controllers.manage.routes.OpportunityController.showOverviewPage(opp.id).url)), displayUserName = Some("Portfolio Peter")) {
 

--- a/src/main/twirl/views/manage/opportunityOverview.scala.html
+++ b/src/main/twirl/views/manage/opportunityOverview.scala.html
@@ -6,7 +6,7 @@
     Some("Portfolio Peter")
 }
 
-@import views.html.partials._
+@import helpers._
 
 @actionLink = @{
     if (opportunity.publishedAt.isEmpty) controllers.manage.routes.OpportunityController.publish(opportunity.id)

--- a/src/main/twirl/views/manage/opportunityOverview.scala.html
+++ b/src/main/twirl/views/manage/opportunityOverview.scala.html
@@ -124,7 +124,7 @@ backLink=Some(BackLink("Opportunity library", controllers.manage.routes.Opportun
                             @app.sections.sortBy(_.sectionNumber).map { fs =>
                                 <tr>
                                     <td>
-                                        @fs.sectionNumber. <a id="section-@fs.sectionNumber-link"
+                                        @fs.sectionNumber.num. <a id="section-@fs.sectionNumber-link"
                                                               href="@controllers.manage.routes.OpportunityController.viewQuestions(opportunity.id, fs.sectionNumber)"
                                                             > @fs.title</a>
                                     </td>

--- a/src/main/twirl/views/manage/opportunityOverview.scala.html
+++ b/src/main/twirl/views/manage/opportunityOverview.scala.html
@@ -124,7 +124,7 @@ backLink=Some(BackLink("Opportunity library", controllers.manage.routes.Opportun
                             @app.sections.sortBy(_.sectionNumber).map { fs =>
                                 <tr>
                                     <td>
-                                        @fs.sectionNumber.num. <a id="section-@fs.sectionNumber-link"
+                                        @fs.sectionNumber.num. <a id="section-@fs.sectionNumber.num-link"
                                                               href="@controllers.manage.routes.OpportunityController.viewQuestions(opportunity.id, fs.sectionNumber)"
                                                             > @fs.title</a>
                                     </td>

--- a/src/main/twirl/views/manage/opportunityPreview.scala.html
+++ b/src/main/twirl/views/manage/opportunityPreview.scala.html
@@ -1,10 +1,10 @@
-@(backUrl: String, opportunity: Opportunity, sectionNumber: Int, appForm: ApplicationForm)
+@(backUrl: String, opportunity: Opportunity, sectionNumber: OppSectionNumber, appForm: ApplicationForm)
 
     @import eu.timepit.refined.auto._
     @import partials._
 
-@sectionLink(title: String, sectionNum: Int) = {
-    <span class="part-number"> @sectionNum. </span>
+@sectionLink(title: String, sectionNum: OppSectionNumber) = {
+    <span class="part-number"> @sectionNum.num. </span>
 @if(sectionNum == sectionNumber) {
     @title
 } else {
@@ -20,11 +20,11 @@
 }
 
 @nextSection = @{
-    opportunity.description.find(_.sectionNumber == sectionNumber + 1)
+    sectionNumber.next.flatMap(n => opportunity.description.find(_.sectionNumber == n))
 }
 
 @prevSection = @{
-    opportunity.description.find(_.sectionNumber == sectionNumber - 1)
+    sectionNumber.prev.flatMap(n => opportunity.description.find(_.sectionNumber == n))
 }
 
 @currentSection = @{
@@ -77,7 +77,7 @@
             </div>
 
             <article>
-                <h2 class="heading-large">@s.sectionNumber. @s.title</h2>
+                <h2 class="heading-large">@s.sectionNumber.num. @s.title</h2>
                 @renderSectionText(s, appForm)
             </article>
         }

--- a/src/main/twirl/views/manage/opportunityPreview.scala.html
+++ b/src/main/twirl/views/manage/opportunityPreview.scala.html
@@ -1,13 +1,16 @@
-@(backUrl:String, opportunity: Opportunity, sectionNumber: Int, appForm: ApplicationForm)
+@(backUrl: String, opportunity: Opportunity, sectionNumber: Int, appForm: ApplicationForm)
+
+    @import eu.timepit.refined.auto._
+    @import partials._
 
 @sectionLink(title: String, sectionNum: Int) = {
     <span class="part-number"> @sectionNum. </span>
-        @if(sectionNum == sectionNumber) {
-            @title
-        } else {
-            <a href="@controllers.manage.routes.OpportunityController.showOpportunityPreview(opportunity.id, Some(sectionNum))">@title</a>
-        }
-    }
+@if(sectionNum == sectionNumber) {
+    @title
+} else {
+    <a href="@controllers.manage.routes.OpportunityController.showOpportunityPreview(opportunity.id, Some(sectionNum))">@title</a>
+}
+}
 
 @titleCols() = @{
     val titles = opportunity.description.sortBy(_.sectionNumber).map(s => (s.title, s.sectionNumber)).zipWithIndex
@@ -29,115 +32,109 @@
     opportunity.description.find(_.sectionNumber == sectionNumber)
 }
 
-@import views.html.partials._
+<div class="grid-row">
+    <div class="column-two-thirds">
+        <header class="page-header">
+            <h1 class="heading-xlarge">@opportunity.title</h1>
+        </header>
 
-
-    <div class="grid-row">
-        <div class="column-two-thirds">
-
-
-            <header class="page-header">
-                <h1 class="heading-xlarge">@opportunity.title</h1>
-            </header>
-
-            <aside>
-                <a class="js-navigation-toggle show-all-parts" data-for="#nav-container">
-                    Show all parts of this opportunity</a>
-                <div id="nav-container">
-                    <nav role="navigation" class="page-navigation" aria-label="Navigation">
-                        <ol>
-                        @titleCols.map { case ((col1, idx), _) =>
+        <aside>
+            <a class="js-navigation-toggle show-all-parts" data-for="#nav-container">
+                Show all parts of this opportunity</a>
+            <div id="nav-container">
+                <nav role="navigation" class="page-navigation" aria-label="Navigation">
+                    <ol>
+                    @titleCols.map { case (((title, sectionNum), idx), _) =>
+                    <li id="title-@(idx + 1)">
+                    @sectionLink(title, sectionNum)
+                    </li>
+                    }
+                    </ol>
+                    <ol>
+                    @titleCols.map { case (_, col2) =>
+                        @col2.map { case ((title, sectionNum), idx) =>
                         <li id="title-@(idx + 1)">
-                        @sectionLink(col1._1, col1._2)
+                        @sectionLink(title, sectionNum)
                         </li>
-                        }
-                        </ol>
-                        <ol>
-                        @titleCols.map { case (_, col2) =>
-                            @col2.map { case (t, idx) =>
-                            <li id="title-@(idx + 1)">
-                            @sectionLink(t._1, t._2)
-                            </li>
-                            }.getOrElse("")
-                        }
-                        </ol>
-                    </nav>
-                </div>
-            </aside>
+                        }.getOrElse("")
+                    }
+                    </ol>
+                </nav>
+            </div>
+        </aside>
 
-            @currentSection.map { s =>
+        @currentSection.map { s =>
 
-                <div class="rifs-summary-panel">
-                    <aside role="complementary" class="notice">
-                        <div class="column-half definition-list">
-                            <dl>
-                                <dt class="heading-small">Deadline</dt>
-                                <dd>Apply any time</dd>
-                            </dl>
-                        </div>
+            <div class="rifs-summary-panel">
+                <aside role="complementary" class="notice">
+                    <div class="column-half definition-list">
+                        <dl>
+                            <dt class="heading-small">Deadline</dt>
+                            <dd>Apply any time</dd>
+                        </dl>
+                    </div>
 
-                        <div class="column-half definition-list">
-                            <dl>
-                                <dt class="heading-small">Value</dt>
-                                <dd>&pound;@("%,.0f".format(opportunity.value.amount)) @opportunity.value.unit</dd>
-                            </dl>
-                        </div>
-                    </aside>
-                </div>
-
-                <article>
-                    <h2 class="heading-large">@s.sectionNumber. @s.title</h2>
-                    @renderSectionText(s, appForm)
-                </article>
-
-                <footer>
-                    <nav class="govuk-previous-and-next-navigation" role="navigation" aria-label="Pagination">
-                        <ul class="group">
-                            @prevSection.map { s =>
-                            <li class="previous-page">
-                                <a href="@controllers.manage.routes.OpportunityController.showOpportunityPreview(opportunity.id, Some(s.sectionNumber))"
-                                title="Navigate to the previous page."
-                                rel="previous">
-                                    <span class="pagination-part-title">Previous</span>
-                                    <span class="pagination-part-label">@s.title</span>
-                                </a>
-                            </li>
-                            }.getOrElse {
-                                <li class="previous-page" aria-hidden="true"></li>
-                            }
-
-                            @nextSection.map { s =>
-                            <li class="next-page">
-                                <a href="@controllers.manage.routes.OpportunityController.showOpportunityPreview(opportunity.id, Some(s.sectionNumber))"
-                                title="Navigate to the next page."
-                                rel="next">
-                                    <span class="pagination-part-title">Next</span>
-                                    <span class="pagination-label">@s.title</span>
-                                </a>
-                            </li>
-                            }.getOrElse {
-                                <li class="next-page" aria-hidden="true"></li>
-                            }
-                        </ul>
-                    </nav>
-                </footer>
+                    <div class="column-half definition-list">
+                        <dl>
+                            <dt class="heading-small">Value</dt>
+                            <dd>&pound;@("%,.0f".format(opportunity.value.amount)) @opportunity.value.unit</dd>
+                        </dl>
+                    </div>
+                </aside>
             </div>
 
-
-        <div id="support-column" class="column-third">
-            <aside role="complementary">
-                <hr class="hr-blue">
-                <h2 class="heading-medium no-top-margin">Support</h2>
-                <ul class="list spacious">
-
-                    <li>
-                        <a href="@controllers.manage.routes.OpportunityController.showPMGuidancePage(backUrl)">Guidance on
-                            seminars</a>
+            <article>
+                <h2 class="heading-large">@s.sectionNumber. @s.title</h2>
+                @renderSectionText(s, appForm)
+            </article>
+        }
+        <footer>
+            <nav class="govuk-previous-and-next-navigation" role="navigation" aria-label="Pagination">
+                <ul class="group">
+                    @prevSection.map { s =>
+                    <li class="previous-page">
+                        <a href="@controllers.manage.routes.OpportunityController.showOpportunityPreview(opportunity.id, Some(s.sectionNumber))"
+                        title="Navigate to the previous page."
+                        rel="previous">
+                            <span class="pagination-part-title">Previous</span>
+                            <span class="pagination-part-label">@s.title</span>
+                        </a>
                     </li>
+                    }.getOrElse {
+                        <li class="previous-page" aria-hidden="true"></li>
+                    }
 
+                    @nextSection.map { s =>
+                    <li class="next-page">
+                        <a href="@controllers.manage.routes.OpportunityController.showOpportunityPreview(opportunity.id, Some(s.sectionNumber))"
+                        title="Navigate to the next page."
+                        rel="next">
+                            <span class="pagination-part-title">Next</span>
+                            <span class="pagination-label">@s.title</span>
+                        </a>
+                    </li>
+                    }.getOrElse {
+                        <li class="next-page" aria-hidden="true"></li>
+                    }
                 </ul>
-            </aside>
-        </div>
-
+            </nav>
+        </footer>
     </div>
-}
+
+
+    <div id="support-column" class="column-third">
+        <aside role="complementary">
+            <hr class="hr-blue">
+            <h2 class="heading-medium no-top-margin">Support</h2>
+            <ul class="list spacious">
+
+                <li>
+                    <a href="@controllers.manage.routes.OpportunityController.showPMGuidancePage(backUrl)">Guidance on
+                        seminars</a>
+                </li>
+
+            </ul>
+        </aside>
+    </div>
+
+</div>

--- a/src/main/twirl/views/manage/opportunityPreview.scala.html
+++ b/src/main/twirl/views/manage/opportunityPreview.scala.html
@@ -44,12 +44,12 @@
                 <nav role="navigation" class="page-navigation" aria-label="Navigation">
                     <ol>
                     @titleCols._1.map { case ((title, sectionNum)) =>
-                    <li id="title-@(sectionNum)"> @sectionLink(title, sectionNum) </li>
+                    <li id="title-@(sectionNum.num)"> @sectionLink(title, sectionNum) </li>
                     }
                     </ol>
                     <ol>
                     @titleCols._2.map { case ((title, sectionNum)) =>
-                    <li id="title-@(sectionNum)"> @sectionLink(title, sectionNum) </li>
+                    <li id="title-@(sectionNum.num)"> @sectionLink(title, sectionNum) </li>
                     }
                     </ol>
                 </nav>

--- a/src/main/twirl/views/manage/opportunityPreview.scala.html
+++ b/src/main/twirl/views/manage/opportunityPreview.scala.html
@@ -13,11 +13,10 @@
 }
 
 @titleCols() = @{
-    val titles = opportunity.description.sortBy(_.sectionNumber).map(s => (s.title, s.sectionNumber)).zipWithIndex
+    val titles = opportunity.description.sortBy(_.sectionNumber).map(s => (s.title, s.sectionNumber))
     val midpoint: Int = Math.round(titles.length / 2.0).toInt
-    val (leftCols, b) = titles.splitAt(midpoint)
-    val rightCols = b.map(Some(_)) :+ None
-    leftCols.zip(rightCols)
+    val (leftCols, rightCols) = titles.splitAt(midpoint)
+    (leftCols, rightCols)
 }
 
 @nextSection = @{
@@ -44,19 +43,13 @@
             <div id="nav-container">
                 <nav role="navigation" class="page-navigation" aria-label="Navigation">
                     <ol>
-                    @titleCols.map { case (((title, sectionNum), idx), _) =>
-                    <li id="title-@(idx + 1)">
-                    @sectionLink(title, sectionNum)
-                    </li>
+                    @titleCols._1.map { case ((title, sectionNum)) =>
+                    <li id="title-@(sectionNum)"> @sectionLink(title, sectionNum) </li>
                     }
                     </ol>
                     <ol>
-                    @titleCols.map { case (_, col2) =>
-                        @col2.map { case ((title, sectionNum), idx) =>
-                        <li id="title-@(idx + 1)">
-                        @sectionLink(title, sectionNum)
-                        </li>
-                        }.getOrElse("")
+                    @titleCols._2.map { case ((title, sectionNum)) =>
+                    <li id="title-@(sectionNum)"> @sectionLink(title, sectionNum) </li>
                     }
                     </ol>
                 </nav>

--- a/src/main/twirl/views/manage/previewDeadlines.scala.html
+++ b/src/main/twirl/views/manage/previewDeadlines.scala.html
@@ -6,9 +6,7 @@
         backUrl: Option[String]
 )
 
-@formatId(id: Long) = @{
-    f"RIFS$id%05d"
-}
+@import views.html.helpers._
 
 @main(s"${opp.title} - RIFS", backLink = Some(BackLink("Opportunity template", controllers.manage.routes.OpportunityController.showOverviewPage(opp.id).url)), displayUserName=Some("Portfolio Peter")) {
     <div class="grid-row">

--- a/src/main/twirl/views/manage/previewDefaultOpportunity.scala.html
+++ b/src/main/twirl/views/manage/previewDefaultOpportunity.scala.html
@@ -1,15 +1,16 @@
-@(backUrl:String, opportunity: Opportunity, sectionNumber: Int, appForm: ApplicationForm)
+@(backUrl: String, opportunity: Opportunity, sectionNumber: OppSectionNumber, appForm: ApplicationForm)
 
-@import views.html.helpers._
+    @import eu.timepit.refined.auto._
+    @import helpers._
 
-@sectionLink(title: String, sectionNum: Int) = {
-    <span class="part-number"> @sectionNum. </span>
-        @if(sectionNum == sectionNumber) {
-            @title
-        } else {
-            <a href="@controllers.manage.routes.OpportunityController.showOpportunityPreview(opportunity.id, Some(sectionNum))">@title</a>
-        }
-    }
+@sectionLink(title: String, sectionNum: OppSectionNumber) = {
+    <span class="part-number"> @sectionNum.num. </span>
+@if(sectionNum == sectionNumber) {
+    @title
+} else {
+    <a href="@controllers.manage.routes.OpportunityController.showOpportunityPreview(opportunity.id, Some(sectionNum))">@title</a>
+}
+}
 
 @titleCols() = @{
     val titles = opportunity.description.sortBy(_.sectionNumber).map(s => (s.title, s.sectionNumber)).zipWithIndex
@@ -20,23 +21,22 @@
 }
 
 @nextSection = @{
-    opportunity.description.find(_.sectionNumber == sectionNumber + 1)
+    sectionNumber.next.flatMap(n => opportunity.description.find(_.sectionNumber == n))
 }
 
 @prevSection = @{
-    opportunity.description.find(_.sectionNumber == sectionNumber - 1)
+    sectionNumber.prev.flatMap(n => opportunity.description.find(_.sectionNumber == n))
 }
 
 @currentSection = @{
     opportunity.description.find(_.sectionNumber == sectionNumber)
 }
 
-@import views.html.partials._
-
-@main(s"Opportunity: ${opportunity.title} - RIFS", backLink=Some(BackLink("Return to opportunity library", controllers.manage.routes.OpportunityController.showOpportunityLibrary().url)), displayUserName=Some("Portfolio Peter")) {
+@main(s"Opportunity: ${opportunity.title} - RIFS", backLink = Some(BackLink("Return to opportunity library", controllers.manage.routes.OpportunityController.showOpportunityLibrary().url)), displayUserName = Some("Portfolio Peter")) {
 
     <div class="rifs-heading-panel">
-        <p>@formatId(opportunity.id.id) <a href="@controllers.manage.routes.OpportunityController.showOverviewPage(opportunity.id).url">Template View</a></p>
+        <p>@formatId(opportunity.id.id) <a href="@controllers.manage.routes.OpportunityController.showOverviewPage(opportunity.id).url">
+            Template View</a></p>
     </div>
     @opportunityPreview(backUrl, opportunity, sectionNumber, appForm)
 }

--- a/src/main/twirl/views/manage/previewDefaultOpportunity.scala.html
+++ b/src/main/twirl/views/manage/previewDefaultOpportunity.scala.html
@@ -1,5 +1,7 @@
 @(backUrl:String, opportunity: Opportunity, sectionNumber: Int, appForm: ApplicationForm)
 
+@import views.html.helpers._
+
 @sectionLink(title: String, sectionNum: Int) = {
     <span class="part-number"> @sectionNum. </span>
         @if(sectionNum == sectionNumber) {

--- a/src/main/twirl/views/manage/previewOppSection.scala.html
+++ b/src/main/twirl/views/manage/previewOppSection.scala.html
@@ -1,27 +1,27 @@
 @(
-opp: Opportunity,
-sectionNumber: Int,
-backUrl: Option[String]
+        opp: Opportunity,
+        sectionNumber: Int,
+        backUrl: Option[String]
 )
 
-@import helpers._
+    @import helpers._
 
 @currentSection = @{
-opp.description.find(_.sectionNumber == sectionNumber)
+    opp.description.find(_.sectionNumber == sectionNumber)
 }
 
-@main(s"${opp.title} - RIFS", backLink=Some(BackLink("Opportunity template",controllers.manage.routes.OpportunityController.showOverviewPage(opp.id).url)), displayUserName=Some("Portfolio Peter")) {
+@main(s"${opp.title} - RIFS", backLink = Some(BackLink("Opportunity template", controllers.manage.routes.OpportunityController.showOverviewPage(opp.id).url)), displayUserName = Some("Portfolio Peter")) {
     <section>
         <h1 class="heading-xlarge">
             <span class="heading-secondary">@formatId(opp.id.id): @opp.title</span>
+            @currentSection.map(_.title.value)</h1>
 
-            @currentSection.map { s =>
-                @s.title</h1>
-        @s.text.map(_.split("\n\n")).map { ps =>
-            @ps.map { p =>
-                <p class="text preview-text">@p</p>
+        @currentSection.map { s =>
+            @s.text.map(_.value.split("\n\n")).map { ps =>
+                @ps.map { p =>
+                    <p class="text preview-text">@p</p>
+                }
             }
-        }
         }
 
         <div class="rifs-form-buttons">

--- a/src/main/twirl/views/manage/previewOppSection.scala.html
+++ b/src/main/twirl/views/manage/previewOppSection.scala.html
@@ -4,7 +4,7 @@ sectionNumber: Int,
 backUrl: Option[String]
 )
 
-@import views.html.partials._
+@import helpers._
 
 @currentSection = @{
 opp.description.find(_.sectionNumber == sectionNumber)

--- a/src/main/twirl/views/manage/previewOppSection.scala.html
+++ b/src/main/twirl/views/manage/previewOppSection.scala.html
@@ -1,6 +1,6 @@
 @(
         opp: Opportunity,
-        sectionNumber: Int,
+        sectionNumber: OppSectionNumber,
         backUrl: Option[String]
 )
 

--- a/src/main/twirl/views/manage/previewPublishOpportunity.scala.html
+++ b/src/main/twirl/views/manage/previewPublishOpportunity.scala.html
@@ -1,10 +1,10 @@
 @(backUrl:String, opportunity: Opportunity, sectionNumber: OppSectionNumber, appForm: ApplicationForm)
 
 @import helpers._
-@import eu.timepit.refined.auto._
+@import views.html.manage.opportunityPreview
 
 @sectionLink(title: String, sectionNum: OppSectionNumber) = {
-    <span class="part-number"> @sectionNum. </span>
+    <span class="part-number"> @sectionNum.num. </span>
         @if(sectionNum == sectionNumber) {
             @title
         } else {

--- a/src/main/twirl/views/manage/previewPublishOpportunity.scala.html
+++ b/src/main/twirl/views/manage/previewPublishOpportunity.scala.html
@@ -1,8 +1,9 @@
-@(backUrl:String, opportunity: Opportunity, sectionNumber: Int, appForm: ApplicationForm)
+@(backUrl:String, opportunity: Opportunity, sectionNumber: OppSectionNumber, appForm: ApplicationForm)
 
 @import helpers._
+@import eu.timepit.refined.auto._
 
-@sectionLink(title: String, sectionNum: Int) = {
+@sectionLink(title: String, sectionNum: OppSectionNumber) = {
     <span class="part-number"> @sectionNum. </span>
         @if(sectionNum == sectionNumber) {
             @title
@@ -20,18 +21,16 @@
 }
 
 @nextSection = @{
-    opportunity.description.find(_.sectionNumber == sectionNumber + 1)
+    sectionNumber.next.flatMap(n => opportunity.description.find(_.sectionNumber == n))
 }
 
 @prevSection = @{
-    opportunity.description.find(_.sectionNumber == sectionNumber - 1)
+    sectionNumber.prev.flatMap(n => opportunity.description.find(_.sectionNumber == n))
 }
 
 @currentSection = @{
     opportunity.description.find(_.sectionNumber == sectionNumber)
 }
-
-@import views.html.partials._
 
 @main(s"Opportunity: ${opportunity.title} - RIFS", backLink=Some(BackLink("Return to opportunity library", controllers.manage.routes.OpportunityController.showOpportunityLibrary().url)), displayUserName=Some("Portfolio Peter")) {
 

--- a/src/main/twirl/views/manage/previewPublishOpportunity.scala.html
+++ b/src/main/twirl/views/manage/previewPublishOpportunity.scala.html
@@ -1,5 +1,7 @@
 @(backUrl:String, opportunity: Opportunity, sectionNumber: Int, appForm: ApplicationForm)
 
+@import helpers._
+
 @sectionLink(title: String, sectionNum: Int) = {
     <span class="part-number"> @sectionNum. </span>
         @if(sectionNum == sectionNumber) {

--- a/src/main/twirl/views/manage/previewTitle.scala.html
+++ b/src/main/twirl/views/manage/previewTitle.scala.html
@@ -3,9 +3,7 @@
   backUrl: Option[String]
 )
 
-@formatId(id: Long) = @{
-    f"RIFS$id%05d"
-}
+@import views.html.helpers._
 
 @main(s"${opp.title} - RIFS", backLink=Some(BackLink("Opportunity template",controllers.manage.routes.OpportunityController.showOverviewPage(opp.id).url)), displayUserName=Some("Portfolio Peter")) {
     <div class="grid-row">

--- a/src/main/twirl/views/manage/publishedOpportunity.scala.html
+++ b/src/main/twirl/views/manage/publishedOpportunity.scala.html
@@ -1,6 +1,6 @@
 @(oppid: OpportunityId, emailto: String, submittime: String)
 
-@import views.html.partials._
+@import views.html.helpers._
 
 @main(s"Opportunity submitted - RIFS", displayUserName=Some("Portfolio Peter")) {
 <!-- main content -->

--- a/src/main/twirl/views/manage/showOpportunityLibrary.scala.html
+++ b/src/main/twirl/views/manage/showOpportunityLibrary.scala.html
@@ -1,5 +1,7 @@
 @(backUrl:String, os: Seq[controllers.manage.OpportunityLibraryEntry])
 
+@import helpers._
+
 @main("Opportunity list - RIFS", backLink=Some(BackLink("Create new opportunity", controllers.manage.routes.OpportunityController.showNewOpportunityForm().url)), displayUserName=Some("Portfolio Peter")) {
 
     <!-- sidebar -->
@@ -34,9 +36,9 @@
                     </tr>
                 </thead>
                 <tbody>
-                @os.sortBy(_.id.id).map { o =>
+                @os.sortBy(_.id).map { o =>
                     <tr>
-                        <td data-label="Ref.">@("%04d".format(o.id.id))</td>
+                        <td data-label="Ref.">@formatId(o.id.id)</td>
                         <td data-label="Title"><a href=@controllers.manage.routes.OpportunityController.showOpportunityPreview(o.id, None).url>@o.title</a></td>
                         <td data-label="Status">@o.status</td>
                         <td data-label="Structure">@o.structure</td>

--- a/src/main/twirl/views/manage/viewDeadlines.scala.html
+++ b/src/main/twirl/views/manage/viewDeadlines.scala.html
@@ -4,7 +4,7 @@
         questions: Map[String, Question],
         answers: play.api.libs.json.JsObject)
 
-@import views.html.partials._
+@import helpers._
 
 @main(s"${opp.title} - RIFS", backLink = Some(BackLink("Opportunity template", controllers.manage.routes.OpportunityController.showOverviewPage(opp.id).url)), displayUserName=Some("Portfolio Peter")) {
     <div class="grid-row">

--- a/src/main/twirl/views/manage/viewGrantValue.scala.html
+++ b/src/main/twirl/views/manage/viewGrantValue.scala.html
@@ -4,7 +4,7 @@
 )
 
 
-@import views.html.partials._
+@import views.html.helpers._
 
 @main(s"${opp.title} - RIFS", backLink=Some(BackLink("Opportunity template",controllers.manage.routes.OpportunityController.showOverviewPage(opp.id).url)), displayUserName=Some("Portfolio Peter")) {
     <div class="grid-row">

--- a/src/main/twirl/views/manage/viewOppSection.scala.html
+++ b/src/main/twirl/views/manage/viewOppSection.scala.html
@@ -1,7 +1,7 @@
 @(
         opp: Opportunity,
         appForm: ApplicationForm,
-        sectionNumber: Int,
+        sectionNumber: OppSectionNumber,
         backUrl: Option[String] = None
 )
 

--- a/src/main/twirl/views/manage/viewOppSection.scala.html
+++ b/src/main/twirl/views/manage/viewOppSection.scala.html
@@ -4,8 +4,9 @@
         sectionNumber: Int,
         backUrl: Option[String] = None
 )
-    @import views.html.partials._
 
+@import partials._
+@import helpers._
 
 @currentSection = @{
     opp.description.find(_.sectionNumber == sectionNumber)

--- a/src/main/twirl/views/manage/viewTitle.scala.html
+++ b/src/main/twirl/views/manage/viewTitle.scala.html
@@ -2,7 +2,7 @@
   opp: Opportunity
 )
 
-@import views.html.partials._
+@import helpers._
 
 @main(s"${opp.title} - RIFS", backLink=Some(BackLink("Opportunity template",controllers.manage.routes.OpportunityController.showOverviewPage(opp.id).url)), displayUserName=Some("Portfolio Peter")) {
     <div class="grid-row">

--- a/src/main/twirl/views/manage/whatWeWillAskPreview.scala.html
+++ b/src/main/twirl/views/manage/whatWeWillAskPreview.scala.html
@@ -1,4 +1,4 @@
-@(backUrl: String, opp: Opportunity, sectionNumber: Int, appForm: ApplicationForm)
+@(backUrl: String, opp: Opportunity, sectionNumber: OppSectionNumber, appForm: ApplicationForm)
 
 @import partials._
 
@@ -22,7 +22,7 @@
 
             @currentSection.map { s =>
                 <article>
-                    <h2 class="heading-large">@s.sectionNumber. @s.title</h2>
+                    <h2 class="heading-large">@s.sectionNumber.num. @s.title</h2>
                     <div class="text">
                     @renderSectionText(s, appForm)
                     </div>

--- a/src/main/twirl/views/partials/appPreview.scala.html
+++ b/src/main/twirl/views/partials/appPreview.scala.html
@@ -1,15 +1,15 @@
 @(
         app: ApplicationDetail,
-        answers: Map[Int, Seq[forms.Field]]
+        answers: Map[AppSectionNumber, Seq[forms.Field]]
 )
 
 <article>
     @app.applicationForm.sections.sortBy(_.sectionNumber).map { formSection =>
-        @app.sections.find(_.sectionNumber == formSection.sectionNumber).map { section =>
+        @app.section(formSection.sectionNumber).map { section =>
             @appSectionPreview(app.sectionDetail(section.sectionNumber), section.answers)
         }.getOrElse {
             <div>
-                <p class="heading-medium">@formSection.sectionNumber. @formSection.title</p>
+                <p class="heading-medium">@formSection.sectionNumber.num. @formSection.title</p>
                 <p class="text">You have not supplied any answers for this section.</p>
             </div>
 

--- a/src/main/twirl/views/partials/appPreview.scala.html
+++ b/src/main/twirl/views/partials/appPreview.scala.html
@@ -3,17 +3,11 @@
         answers: Map[AppSectionNumber, Seq[forms.Field]]
 )
 
+@import views.html.partials.appSectionPreview
+
 <article>
     @app.applicationForm.sections.sortBy(_.sectionNumber).map { formSection =>
-        @app.section(formSection.sectionNumber).map { section =>
-            @appSectionPreview(app.sectionDetail(section.sectionNumber), section.answers)
-        }.getOrElse {
-            <div>
-                <p class="heading-medium">@formSection.sectionNumber.num. @formSection.title</p>
-                <p class="text">You have not supplied any answers for this section.</p>
-            </div>
-
-        }
+        @app.sectionDetail(formSection.sectionNumber).map(s => appSectionPreview(s))
     }
 
 <p class="rifs-form-buttons">

--- a/src/main/twirl/views/partials/appSectionPreview.scala.html
+++ b/src/main/twirl/views/partials/appSectionPreview.scala.html
@@ -1,8 +1,15 @@
 @(
-        app: ApplicationSectionDetail,
-        answers: play.api.libs.json.JsObject
+        sectionDetail: ApplicationSectionDetail
 )
-<div>
-    <h2 class="heading-medium">@app.formSection.sectionNumber . @app.formSection.title </h2>
-    @app.formSection.fields.map(_.renderPreview(app.formSection.questionMap, answers))
-</div>
+
+@sectionDetail.section.map { section =>
+    <div>
+        <h2 class="heading-medium">@sectionDetail.formSection.sectionNumber.num. @sectionDetail.formSection.title </h2>
+        @sectionDetail.formSection.fields.map(_.renderPreview(sectionDetail.formSection.questionMap, section.answers))
+    </div>
+}.getOrElse {
+    <div>
+        <p class="heading-medium">@sectionDetail.formSection.sectionNumber.num. @sectionDetail.formSection.title</p>
+        <p class="text">You have not supplied any answers for this section.</p>
+    </div>
+}

--- a/src/main/twirl/views/partials/formatId.scala.html
+++ b/src/main/twirl/views/partials/formatId.scala.html
@@ -1,3 +1,0 @@
-@(id: Long)
-
-@{f"RIFS $id%04d"}

--- a/src/main/twirl/views/partials/renderSectionText.scala.html
+++ b/src/main/twirl/views/partials/renderSectionText.scala.html
@@ -3,7 +3,7 @@
 @if(s.sectionType == OppSectionType.Questions) {
     @helpers.textForQuestions(appForm)
 } else {
-    @s.text.map(_.split("\n\n")).map { ps =>
+    @s.text.map(_.value.split("\n\n")).map { ps =>
         @ps.map { p =>
             <p class="text">@p</p>
         }

--- a/src/main/twirl/views/partials/sidebar.scala.html
+++ b/src/main/twirl/views/partials/sidebar.scala.html
@@ -1,8 +1,9 @@
 @(
         opportunityId: OpportunityId,
-        sectionCount: Int,
-        completedSectionCount: Int
+        sectionCount: NonNegativeInt,
+        completedSectionCount: NonNegativeInt
 )
+@import partials._
 @sidebarNoCounter(opportunityId)
 <div class="rifs-step-panel">
     <p class="rifs-step-content">

--- a/src/main/twirl/views/partials/statusText.scala.html
+++ b/src/main/twirl/views/partials/statusText.scala.html
@@ -1,7 +1,7 @@
-@(overview: ApplicationDetail, sectionNumber: Int)
+@(overview: ApplicationDetail, sectionNumber: AppSectionNumber)
 <span class="bold">
-    @overview.sections.find(_.sectionNumber == sectionNumber).map(os => os.status).getOrElse("Not started")
+    @overview.section(sectionNumber).map(os => os.status).getOrElse("Not started")
 </span>
-@if(overview.sections.find(_.sectionNumber == sectionNumber).map(os => os.status).getOrElse("Not started") == "Completed") {
+@if(overview.section(sectionNumber).map(os => os.status).getOrElse("Not started") == "Completed") {
    <img src="@routes.Assets.at("images/checkmark-26x26.png")" alt="" width=26 height=26 class="greentick">
 }

--- a/src/main/twirl/views/personalReferenceForm.scala.html
+++ b/src/main/twirl/views/personalReferenceForm.scala.html
@@ -7,6 +7,7 @@
         hints:List[forms.validation.FieldHint]
 )
 @import partials._
+@import helpers._
 
 @main(s"Create Application Reference - RIFS",
         backLink=Some(BackLink("Return to opportunity list",controllers.routes.OpportunityController.showOpportunities().url)),

--- a/src/main/twirl/views/renderers/costItemField.scala.html
+++ b/src/main/twirl/views/renderers/costItemField.scala.html
@@ -4,6 +4,9 @@
         errs: Seq[forms.validation.FieldError],
         hints: Seq[forms.validation.FieldHint])
 
+@import helpers._
+@import eu.timepit.refined.auto._
+
 @errors = @{
     errs.filter(p => p.path == field.name || p.path.startsWith(s"${field.name}."))
 }
@@ -27,10 +30,10 @@
 }
 
 @questions.get(field.name).map { q => <p class="question">@q.text</p>
-@q.longDescription.map { desc => @desc.split("\n").map { text => <p>@text</p> } }
+@q.longDescription.map { desc => @splitLines(desc).map { text => <p>@text</p> } }
     <details>
         <summary role="button"><span class="summary">Help with this section</span></summary>
-        <div class="panel panel-border-narrow">@for(line <- q.helpText.getOrElse("").split("\n")) {
+        <div class="panel panel-border-narrow">@for(line <- splitLines(q.helpText)) {
             <p>@line</p>
         }</div>
     </details>

--- a/src/main/twirl/views/renderers/textAreaField.scala.html
+++ b/src/main/twirl/views/renderers/textAreaField.scala.html
@@ -4,6 +4,7 @@
         errs: Seq[forms.validation.FieldError],
         hints: Seq[forms.validation.FieldHint])
 
+@import helpers._
 
 @errors = @{
     errs.filter(p => p.path == field.name || p.path.startsWith(s"${field.name}."))
@@ -16,7 +17,7 @@
     <p class="text">@q.longDescription</p>
     <details>
         <summary role="button"><span class="summary">Help with this section</span></summary>
-        <div class="panel panel-border-narrow">@for(line <- q.helpText.getOrElse("").split("\n")) {
+        <div class="panel panel-border-narrow">@for(line <- splitLines(q.helpText)) {
             <p>@line</p>
         }</div>
     </details>

--- a/src/main/twirl/views/sectionForm.scala.html
+++ b/src/main/twirl/views/sectionForm.scala.html
@@ -4,7 +4,9 @@
         errs: List[forms.validation.FieldError],
         hints:List[forms.validation.FieldHint]
 )
+
 @import partials._
+@import helpers._
 
 @main(s"${app.formSection.title} - RIFS", backLink=Some(BackLink("Return to application overview",controllers.routes.ApplicationController.show(app.id).url)), displayUserName=Some("Experienced Eric")) {
     <div class="grid-row">

--- a/src/main/twirl/views/sectionList.scala.html
+++ b/src/main/twirl/views/sectionList.scala.html
@@ -5,7 +5,9 @@
         errs: List[forms.validation.FieldError],
         hints:List[forms.validation.FieldHint]
 )
+
 @import partials._
+@import helpers._
 
 @main(s"${app.formSection.title} - RIFS", backLink=Some(BackLink("Return to application overview",controllers.routes.ApplicationController.show(app.id).url)), displayUserName=Some("Experienced Eric")) {
     <div class="grid-row">

--- a/src/main/twirl/views/sectionPreview.scala.html
+++ b/src/main/twirl/views/sectionPreview.scala.html
@@ -6,7 +6,7 @@
         editButton: Option[String]
 )
 
-@import partials._
+@import helpers._
 
 @main(s"${app.formSection.title} - RIFS", backLink=Some(BackLink("Return to application overview",controllers.routes.ApplicationController.show(app.id).url)), displayUserName=Some("Experienced Eric")) {
     <div class="grid-row">

--- a/src/main/twirl/views/showApplicationForm.scala.html
+++ b/src/main/twirl/views/showApplicationForm.scala.html
@@ -65,7 +65,7 @@
                         @app.applicationForm.sections.sortBy(_.sectionNumber).map { fs =>
                             <tr>
                                 <td>
-                                    @fs.sectionNumber.num. <a id="section-@fs.sectionNumber-link" href="@controllers.routes.ApplicationController.showSectionForm(app.id, fs.sectionNumber)"> @fs.title</a>
+                                    @fs.sectionNumber.num. <a id="section-@fs.sectionNumber.num-link" href="@controllers.routes.ApplicationController.showSectionForm(app.id, fs.sectionNumber)"> @fs.title</a>
                                 </td>
                                 <td class="status-column">
                                 @statusText(app, fs.sectionNumber)

--- a/src/main/twirl/views/showApplicationForm.scala.html
+++ b/src/main/twirl/views/showApplicationForm.scala.html
@@ -1,5 +1,6 @@
 @import models._
 @import partials._
+@import helpers._
 
 @(app: ApplicationDetail, errs: Seq[forms.validation.SectionError])
 

--- a/src/main/twirl/views/showApplicationForm.scala.html
+++ b/src/main/twirl/views/showApplicationForm.scala.html
@@ -65,7 +65,7 @@
                         @app.applicationForm.sections.sortBy(_.sectionNumber).map { fs =>
                             <tr>
                                 <td>
-                                    @fs.sectionNumber. <a id="section-@fs.sectionNumber-link" href="@controllers.routes.ApplicationController.showSectionForm(app.id, fs.sectionNumber)"> @fs.title</a>
+                                    @fs.sectionNumber.num. <a id="section-@fs.sectionNumber-link" href="@controllers.routes.ApplicationController.showSectionForm(app.id, fs.sectionNumber)"> @fs.title</a>
                                 </td>
                                 <td class="status-column">
                                 @statusText(app, fs.sectionNumber)

--- a/src/main/twirl/views/showOpportunity.scala.html
+++ b/src/main/twirl/views/showOpportunity.scala.html
@@ -2,9 +2,9 @@
 
 @import eu.timepit.refined.auto._
 
-@sectionLink(title: String, sectionNum: Int) = {
+@sectionLink(title: String, sectionNum: OppSectionNumber) = {
     <span class="part-number">
-        @sectionNum.
+        @sectionNum.num.
     </span>
 @if(sectionNum == section.sectionNumber) {
     @title
@@ -22,11 +22,11 @@
 }
 
 @nextSection = @{
-    opportunity.description.find(_.sectionNumber == section.sectionNumber + 1)
+    section.sectionNumber.next.flatMap(n => opportunity.description.find(_.sectionNumber == n))
 }
 
 @prevSection = @{
-    opportunity.description.find(_.sectionNumber == section.sectionNumber - 1)
+    section.sectionNumber.prev.flatMap(n => opportunity.description.find(_.sectionNumber == n))
 }
 
 @currentSection = @{
@@ -94,7 +94,7 @@
             </div>
 
             <article>
-                <h2 class="heading-large">@section.sectionNumber. @section.title</h2>
+                <h2 class="heading-large">@section.sectionNumber.num. @section.title</h2>
                 @if(section.sectionType == OppSectionType.Questions) {
                     @helpers.textForQuestions(appForm)
                 } else {

--- a/src/main/twirl/views/showOpportunity.scala.html
+++ b/src/main/twirl/views/showOpportunity.scala.html
@@ -1,5 +1,7 @@
 @(appForm: ApplicationForm, opportunity: Opportunity, section: OpportunityDescriptionSection)
 
+@import eu.timepit.refined.auto._
+
 @sectionLink(title: String, sectionNum: Int) = {
     <span class="part-number">
         @sectionNum.

--- a/src/test/scala/controllers/JsonHelpers$Test.scala
+++ b/src/test/scala/controllers/JsonHelpers$Test.scala
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2016  Department for Business, Energy and Industrial Strategy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package controllers
 
 import org.scalatest.{Matchers, OptionValues, WordSpecLike}

--- a/src/test/scala/forms/validation/CurrencyValidatorSpec.scala
+++ b/src/test/scala/forms/validation/CurrencyValidatorSpec.scala
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2016  Department for Business, Energy and Industrial Strategy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package forms.validation
 
 import cats.data.Validated.Invalid

--- a/src/test/scala/forms/validation/DateFieldValidatorTest.scala
+++ b/src/test/scala/forms/validation/DateFieldValidatorTest.scala
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2016  Department for Business, Energy and Industrial Strategy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package forms.validation
 
 import forms.DateValues

--- a/src/test/scala/forms/validation/DateTimeRangeValidatorTest.scala
+++ b/src/test/scala/forms/validation/DateTimeRangeValidatorTest.scala
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2016  Department for Business, Energy and Industrial Strategy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package forms.validation
 
 import cats.data.Validated.{Invalid, Valid}

--- a/src/test/scala/forms/validation/DateWithDaysValidatorSpec.scala
+++ b/src/test/scala/forms/validation/DateWithDaysValidatorSpec.scala
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2016  Department for Business, Energy and Industrial Strategy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package forms.validation
 
 import cats.data.Validated.Valid

--- a/src/test/scala/models/OpportunityTest.scala
+++ b/src/test/scala/models/OpportunityTest.scala
@@ -17,10 +17,10 @@
 
 package models
 
+import eu.timepit.refined.auto._
+import eu.timepit.refined.numeric._
 import org.joda.time.{DateTime, LocalDate}
 import org.scalatest.{Matchers, OptionValues, WordSpecLike}
-import eu.timepit.refined._
-import eu.timepit.refined.numeric._
 
 class OpportunityTest extends WordSpecLike with Matchers with OptionValues {
   val testDateBeforeCurrent = LocalDate.now.minusMonths(1)
@@ -28,7 +28,7 @@ class OpportunityTest extends WordSpecLike with Matchers with OptionValues {
   val testDateCurrent = LocalDate.now
   val publishedDate: DateTime = DateTime.now.minusMonths(1)
 
-  def opp(startDate: LocalDate, endDate: Option[LocalDate], publishedAt: Option[DateTime]) = Opportunity(OpportunityId(refineMV[Positive](1)), "Test opportunity", startDate, endDate, OpportunityValue(2000.00, "spondulix"), publishedAt, None, Seq())
+  def opp(startDate: LocalDate, endDate: Option[LocalDate], publishedAt: Option[DateTime]) = Opportunity(OpportunityId(1L), "Test opportunity", startDate, endDate, OpportunityValue(2000.00, "spondulix"), publishedAt, None, Seq())
 
   "validate" when {
     "Opportunity is published and starts before current date " should {

--- a/src/test/scala/models/OpportunityTest.scala
+++ b/src/test/scala/models/OpportunityTest.scala
@@ -1,7 +1,26 @@
+/*
+ * Copyright (C) 2016  Department for Business, Energy and Industrial Strategy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package models
 
 import org.joda.time.{DateTime, LocalDate}
 import org.scalatest.{Matchers, OptionValues, WordSpecLike}
+import eu.timepit.refined._
+import eu.timepit.refined.numeric._
 
 class OpportunityTest extends WordSpecLike with Matchers with OptionValues {
   val testDateBeforeCurrent = LocalDate.now.minusMonths(1)
@@ -9,7 +28,7 @@ class OpportunityTest extends WordSpecLike with Matchers with OptionValues {
   val testDateCurrent = LocalDate.now
   val publishedDate: DateTime = DateTime.now.minusMonths(1)
 
-  def opp(startDate: LocalDate, endDate: Option[LocalDate], publishedAt: Option[DateTime]) = Opportunity(OpportunityId(1), "Test opportunity", startDate, endDate, OpportunityValue(2000.00, "spondulix"), publishedAt, None, Seq())
+  def opp(startDate: LocalDate, endDate: Option[LocalDate], publishedAt: Option[DateTime]) = Opportunity(OpportunityId(refineMV[Positive](1)), "Test opportunity", startDate, endDate, OpportunityValue(2000.00, "spondulix"), publishedAt, None, Seq())
 
   "validate" when {
     "Opportunity is published and starts before current date " should {

--- a/src/test/scala/services/ApplicationFormURLsTest.scala
+++ b/src/test/scala/services/ApplicationFormURLsTest.scala
@@ -1,0 +1,21 @@
+package services
+
+import eu.timepit.refined.auto._
+import models.ApplicationFormId
+import org.scalatest.{Matchers, WordSpecLike}
+
+class ApplicationFormURLsTest extends WordSpecLike with Matchers {
+
+  "ApplicationFormURLsTest" should {
+    val urls = new ApplicationFormURLs("")
+    val id = ApplicationFormId(1L)
+
+    "generate correct url for applicationForm" in {
+      urls.applicationForm(id) shouldBe "/application_form/1"
+    }
+
+    "generate correct url for application" in {
+      urls.application(id) shouldBe "/application_form/1/application"
+    }
+  }
+}

--- a/src/test/scala/services/ApplicationURLsTest.scala
+++ b/src/test/scala/services/ApplicationURLsTest.scala
@@ -1,0 +1,65 @@
+package services
+
+import eu.timepit.refined.auto._
+import models.{AppSectionNumber, ApplicationId}
+import org.scalatest.{Matchers, WordSpecLike}
+
+class ApplicationURLsTest extends WordSpecLike with Matchers {
+  val urls = new ApplicationURLs("")
+
+  "ApplicationURLsTest" should {
+
+    val id = ApplicationId(1L)
+    val sectionNum = AppSectionNumber(2)
+    val itemNum = 3
+
+    "generate correct url for items" in {
+      urls.items(id, sectionNum) shouldBe "/application/1/section/2/items"
+    }
+
+    "generate correct url for personalRef" in {
+      urls.personalRef(id) shouldBe "/application/1/personal-ref"
+    }
+
+    "generate correct url for section" in {
+      urls.section(id, sectionNum) shouldBe "/application/1/section/2"
+    }
+
+    "generate correct url for sectionDetail" in {
+      urls.sectionDetail(id, sectionNum) shouldBe "/application/1/section/2/detail"
+    }
+
+    "generate correct url for detail" in {
+      urls.detail(id) shouldBe "/application/1/detail"
+    }
+
+    "generate correct url for application" in {
+      urls.application(id) shouldBe "/application/1"
+    }
+
+    "generate correct url for sections" in {
+      urls.sections(id) shouldBe "/application/1/sections"
+    }
+
+    "generate correct url for complete" in {
+      urls.complete(id, sectionNum) shouldBe "/application/1/section/2/complete"
+    }
+
+    "generate correct url for item" in {
+      urls.item(id, sectionNum, itemNum) shouldBe "/application/1/section/2/item/3"
+    }
+
+    "generate correct url for markNotCompleted" in {
+      urls.markNotCompleted(id, sectionNum) shouldBe "/application/1/section/2/markNotCompleted"
+    }
+
+    "generate correct url for reset" in {
+      urls.reset shouldBe "/reset"
+    }
+
+    "generate correct url for submit" in {
+      urls.submit(id) shouldBe "/application/1/submit"
+    }
+
+  }
+}

--- a/src/test/scala/services/OpportunityURLsTest.scala
+++ b/src/test/scala/services/OpportunityURLsTest.scala
@@ -1,0 +1,47 @@
+package services
+
+import models.{OppSectionNumber, OpportunityId}
+import org.scalatest.{Matchers, WordSpecLike}
+import eu.timepit.refined.auto._
+
+class OpportunityURLsTest extends WordSpecLike with Matchers {
+  val urls = new OpportunityURLs("")
+
+  "OpporunityURLs" should {
+    "generate correct url for summaries" in {
+      urls.opportunitySummaries shouldBe "/opportunity/summaries"
+    }
+
+    "generate correct url for open summaries" in {
+      urls.openOpportunitySummaries shouldBe "/opportunity/open/summaries"
+    }
+
+    val id = OpportunityId(1L)
+    val sectionNumber = OppSectionNumber(2)
+
+    "generate correct url for opportunity" in {
+      urls.opportunity(id) shouldBe "/opportunity/1"
+    }
+
+    "generate correct url for opportunity summary" in {
+      urls.summary(id) shouldBe "/opportunity/1/summary"
+    }
+
+    "generate correct url for description section text" in {
+      urls.descriptionSectionText(id, sectionNumber) shouldBe "/manage/opportunity/1/description/2"
+    }
+
+    "generate correct url for duplicate" in {
+      urls.duplicate(id) shouldBe "/opportunity/1/duplicate"
+    }
+
+    "generate correct url for publish" in {
+      urls.publish(id) shouldBe "/opportunity/1/publish"
+    }
+
+    "generate correct url for applicationForm" in {
+      urls.applicationForm(id) shouldBe "/opportunity/1/application_form"
+    }
+  }
+
+}

--- a/src/test/scala/views/html/EventAudienceFormSpec.scala
+++ b/src/test/scala/views/html/EventAudienceFormSpec.scala
@@ -1,7 +1,24 @@
+/*
+ * Copyright (C) 2016  Department for Business, Energy and Industrial Strategy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package views.html
 
 import eu.timepit.refined._
-import eu.timepit.refined.numeric.{Positive, _}
+import eu.timepit.refined.numeric._
 import forms.TextAreaField
 import forms.validation.FieldHint
 import models._
@@ -36,7 +53,7 @@ class EventAudienceFormSpec extends WordSpecLike with Matchers with OptionValues
       ApplicationId(refineMV[Positive](1)),
       1,
       1,
-      OpportunitySummary(OpportunityId(1), "Research priorities in health care", new LocalDate(), None, OpportunityValue(0, ""), None, None),
+      OpportunitySummary(OpportunityId(refineMV[Positive](1)), "Research priorities in health care", new LocalDate(), None, OpportunityValue(0, ""), None, None),
       fs,
       None)
 

--- a/src/test/scala/views/html/EventAudienceFormSpec.scala
+++ b/src/test/scala/views/html/EventAudienceFormSpec.scala
@@ -1,5 +1,7 @@
 package views.html
 
+import eu.timepit.refined._
+import eu.timepit.refined.numeric.{Positive, _}
 import forms.TextAreaField
 import forms.validation.FieldHint
 import models._
@@ -31,7 +33,7 @@ class EventAudienceFormSpec extends WordSpecLike with Matchers with OptionValues
     val fs: ApplicationFormSection = ApplicationFormSection(5, "Event Audience", Seq(q), SectionTypeForm, Seq(TextAreaField(Some("label"), name, 200)))
 
     val app = ApplicationSectionDetail(
-      ApplicationId(1),
+      ApplicationId(refineMV[Positive](1)),
       1,
       1,
       OpportunitySummary(OpportunityId(1), "Research priorities in health care", new LocalDate(), None, OpportunityValue(0, ""), None, None),

--- a/src/test/scala/views/html/EventAudienceFormSpec.scala
+++ b/src/test/scala/views/html/EventAudienceFormSpec.scala
@@ -44,10 +44,10 @@ class EventAudienceFormSpec extends WordSpecLike with Matchers with OptionValues
   }
 
   def generatePage(values: Option[JsObject]): Html = {
-    val section = values.map(vs => ApplicationSection(3, vs, None))
+    val section = values.map(vs => ApplicationSection(AppSectionNumber(3), vs, None))
     val name = "eventAudience"
     val q = ApplicationFormQuestion(name, "Who is the event's target audience?", None, Option("Help Text"))
-    val fs: ApplicationFormSection = ApplicationFormSection(5, "Event Audience", Seq(q), SectionTypeForm, Seq(TextAreaField(Some("label"), name, 200)))
+    val fs: ApplicationFormSection = ApplicationFormSection(AppSectionNumber(5), "Event Audience", Seq(q), SectionTypeForm, Seq(TextAreaField(Some("label"), name, 200)))
 
     val app = ApplicationSectionDetail(
       ApplicationId(1L),

--- a/src/test/scala/views/html/EventAudienceFormSpec.scala
+++ b/src/test/scala/views/html/EventAudienceFormSpec.scala
@@ -17,7 +17,7 @@
 
 package views.html
 
-import eu.timepit.refined._
+import eu.timepit.refined.auto._
 import eu.timepit.refined.numeric._
 import forms.TextAreaField
 import forms.validation.FieldHint
@@ -46,14 +46,14 @@ class EventAudienceFormSpec extends WordSpecLike with Matchers with OptionValues
   def generatePage(values: Option[JsObject]): Html = {
     val section = values.map(vs => ApplicationSection(3, vs, None))
     val name = "eventAudience"
-    val q = ApplicationFormQuestion(name, "Who is the event's target audience?", Option(""), Option("Help Text"))
+    val q = ApplicationFormQuestion(name, "Who is the event's target audience?", None, Option("Help Text"))
     val fs: ApplicationFormSection = ApplicationFormSection(5, "Event Audience", Seq(q), SectionTypeForm, Seq(TextAreaField(Some("label"), name, 200)))
 
     val app = ApplicationSectionDetail(
-      ApplicationId(refineMV[Positive](1)),
+      ApplicationId(1L),
       1,
       1,
-      OpportunitySummary(OpportunityId(refineMV[Positive](1)), "Research priorities in health care", new LocalDate(), None, OpportunityValue(0, ""), None, None),
+      OpportunitySummary(OpportunityId(1L), "Research priorities in health care", new LocalDate(), None, OpportunityValue(0, ""), None, None),
       fs,
       None)
 


### PR DESCRIPTION
Introduced the `refined` library to place more restrictions on some of the base types, e.g. ensuring Id values are positive and so on. This has also led to more tightening up of some types in general to make things a bit safer, and I also pulled out classes that generate URLs for the `rifs-business` service calls and added some unit tests to ensure they're being correctly generated.